### PR TITLE
pci.c: rework PCI handling, do not use hardcoded MMIO base address

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -25,7 +25,7 @@ u32 dev_locate(void)
 	u32 pci_cap_id;
 
 	/* read capabilities pointer */
-        pci_conf1_read(0, DEV_PCI_BUS,
+        pci_read(0, DEV_PCI_BUS,
 			PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
 			PCI_CAPABILITY_LIST,
 			4, &pci_cap_ptr);
@@ -37,7 +37,7 @@ u32 dev_locate(void)
 
 	while (pci_cap_ptr != 0)
 	{
-		pci_conf1_read(0, DEV_PCI_BUS,
+		pci_read(0, DEV_PCI_BUS,
 				PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
 				pci_cap_ptr,
 				1, &pci_cap_id);
@@ -45,7 +45,7 @@ u32 dev_locate(void)
 		if (pci_cap_id == PCI_CAPABILITIES_POINTER_ID_DEV)
 			break;
 
-		pci_conf1_read(0, DEV_PCI_BUS,
+		pci_read(0, DEV_PCI_BUS,
 				PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
 				pci_cap_ptr,
 				1, &pci_cap_ptr);

--- a/include/dev.h
+++ b/include/dev.h
@@ -60,13 +60,13 @@ static inline u32 dev_read(u32 dev, u32 function, u32 index)
 {
         u32 value;
 
-        pci_conf1_write(0, DEV_PCI_BUS,
+        pci_write(0, DEV_PCI_BUS,
 			PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
 			dev + DEV_OP_OFFSET,
 			4,
 			(u32)(((function & 0xff) << 8) + (index & 0xff)) );
 
-        pci_conf1_read(0, DEV_PCI_BUS,
+        pci_read(0, DEV_PCI_BUS,
 			PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
 			dev + DEV_DATA_OFFSET,
 			4, &value);
@@ -76,13 +76,13 @@ static inline u32 dev_read(u32 dev, u32 function, u32 index)
 
 static inline void dev_write(u32 dev, u32 function, u32 index, u32 value)
 {
-        pci_conf1_write(0, DEV_PCI_BUS,
+        pci_write(0, DEV_PCI_BUS,
 			PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
 			dev + DEV_OP_OFFSET,
 			4,
 			(u32)(((function & 0xff) << 8) + (index & 0xff)) );
 
-        pci_conf1_write(0, DEV_PCI_BUS,
+        pci_write(0, DEV_PCI_BUS,
 			PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
 			dev + DEV_DATA_OFFSET,
 			4, value);

--- a/include/pci.h
+++ b/include/pci.h
@@ -47,11 +47,13 @@
 
 /* From arch/x86/pci/direct.c definitions */
 
-int pci_conf1_read(unsigned int seg, unsigned int bus,
+int (*pci_read)(unsigned int seg, unsigned int bus,
 		   unsigned int devfn, int reg, int len, u32 *value);
 
 
-int pci_conf1_write(unsigned int seg, unsigned int bus,
+int (*pci_write)(unsigned int seg, unsigned int bus,
 		    unsigned int devfn, int reg, int len, u32 value);
+
+void pci_init(void);
 
 #endif /* __PCI_H__ */

--- a/setup.c
+++ b/setup.c
@@ -173,6 +173,7 @@ void setup(void *_lz_base)
 		dev_protect_page(pfn, (u8*)dev_table);
 	}
 
+	pci_init();
 	dev = dev_locate();
 	dev_load_map(dev, (u32)((u64)dev_table));
 	dev_flush_cache(dev);


### PR DESCRIPTION
Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>