### PR TITLE
sha1sum: Optimise rol() helper

### DIFF
--- a/sha1sum.c
+++ b/sha1sum.c
@@ -33,10 +33,7 @@
 static inline u32
 rol( u32 x, int n)
 {
-	__asm__("roll %%cl,%0"
-		:"=r" (x)
-		:"0" (x),"c" (n));
-	return x;
+    return (x << n) | (x >> (-n & 31));
 }
 
 void


### PR DESCRIPTION
Forcing the use of %cl for the rotate count is inefficient.  By expressing the
rotate to the compiler, it can generate code using the `rol $imm` form of the
instruction.

For an -Os build, bloat-o-meter reports:

  add/remove: 0/0 grow/shrink: 0/1 up/down: 0/-879 (-879)
  Function                                     old     new   delta
  transform                                   5350    4471    -879
  Total: Before=49827, After=48948, chg -1.76%

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>