### PR TITLE
entry: Use 4k mappings for the first 2M of RAM

### DIFF
--- a/include/defs.h
+++ b/include/defs.h
@@ -95,6 +95,7 @@
 #define _PAGE_RW       0x002
 #define _PAGE_AD       0x060
 #define _PAGE_PSE      0x080
+#define L1_PT_SHIFT    12 /* 4Kb */
 #define L2_PT_SHIFT    21 /* 2Mb */
 
 /* MSRs */

--- a/lz_header.S
+++ b/lz_header.S
@@ -86,6 +86,7 @@ _entry:
 	addl	%ebp, 0x08 + l3_identmap(%ebp) /* L3[1] => Second L2 */
 	addl	%ebp, 0x10 + l3_identmap(%ebp) /* L3[2] => Third  L2 */
 	addl	%ebp, 0x18 + l3_identmap(%ebp) /* L3[3] => Fourth L2 */
+	addl	%ebp,        l2_identmap(%ebp) /* L2[0] => L1        */
 
 	/* Load GDT */
 	lgdt	gdtr(%ebp)
@@ -275,9 +276,18 @@ ENDDATA(gdt)
 
 	/* 64bit Pagetables, identity map of the first 4G of RAM. */
 
-l2_identmap: /* 4x L2 pages, each mapping 1G of RAM.  No relocations. */
+l1_identmap: /* 1x L1 page, mapping 2M of RAM.  No relocations. */
 	idx = 0
-	.rept 512 * 4
+	.rept 512
+	.quad (idx << L1_PT_SHIFT) + _PAGE_AD + _PAGE_RW + _PAGE_PRESENT
+	idx = idx + 1
+	.endr
+ENDDATA(l1_identmap)
+
+l2_identmap: /* 4x L2 pages, each mapping 1G of RAM.  1 relocation. */
+	.quad l1_identmap + _PAGE_AD + _PAGE_RW + _PAGE_PRESENT
+	idx = 1
+	.rept (512 * 4) - 1
 	.quad (idx << L2_PT_SHIFT) + _PAGE_PSE + _PAGE_AD + _PAGE_RW + _PAGE_PRESENT
 	idx = idx + 1
 	.endr


### PR DESCRIPTION
Using a 2M superpage which covers multiple MTRRs has undefined behaviour.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>