### PR TITLE
PCI: Rework API from scratch

### DIFF
--- a/dev.c
+++ b/dev.c
@@ -25,10 +25,9 @@ u32 dev_locate(void)
 	u32 pci_cap_id;
 
 	/* read capabilities pointer */
-        pci_read(0, DEV_PCI_BUS,
-			PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
-			PCI_CAPABILITY_LIST,
-			4, &pci_cap_ptr);
+	pci_cap_ptr = pci_read32(DEV_PCI_BUS,
+				 PCI_DEVFN(DEV_PCI_DEVICE, DEV_PCI_FUNCTION),
+				 PCI_CAPABILITY_LIST);
 
 	if (INVALID_CAP(pci_cap_ptr))
 		return 0;
@@ -37,21 +36,21 @@ u32 dev_locate(void)
 
 	while (pci_cap_ptr != 0)
 	{
-		pci_read(0, DEV_PCI_BUS,
-				PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
-				pci_cap_ptr,
-				1, &pci_cap_id);
+		pci_cap_id = pci_read8(DEV_PCI_BUS,
+				       PCI_DEVFN(DEV_PCI_DEVICE,
+						 DEV_PCI_FUNCTION),
+				       pci_cap_ptr);
 
 		if (pci_cap_id == PCI_CAPABILITIES_POINTER_ID_DEV)
 			break;
 
-		pci_read(0, DEV_PCI_BUS,
-				PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
-				pci_cap_ptr,
-				1, &pci_cap_ptr);
+		pci_cap_ptr = pci_read8(DEV_PCI_BUS,
+					PCI_DEVFN(DEV_PCI_DEVICE,
+						  DEV_PCI_FUNCTION),
+					pci_cap_ptr);
 	}
 
-        if (INVALID_CAP(pci_cap_ptr))
+	if (INVALID_CAP(pci_cap_ptr))
                 return 0;
 
 	return pci_cap_ptr;

--- a/include/dev.h
+++ b/include/dev.h
@@ -58,34 +58,23 @@
 
 static inline u32 dev_read(u32 dev, u32 function, u32 index)
 {
-        u32 value;
+	pci_write32(DEV_PCI_BUS, PCI_DEVFN(DEV_PCI_DEVICE, DEV_PCI_FUNCTION),
+		    dev + DEV_OP_OFFSET,
+		    (u32)(((function & 0xff) << 8) + (index & 0xff)));
 
-        pci_write(0, DEV_PCI_BUS,
-			PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
-			dev + DEV_OP_OFFSET,
-			4,
-			(u32)(((function & 0xff) << 8) + (index & 0xff)) );
-
-        pci_read(0, DEV_PCI_BUS,
-			PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
-			dev + DEV_DATA_OFFSET,
-			4, &value);
-
-	return value;
+	return pci_read32(DEV_PCI_BUS, PCI_DEVFN(DEV_PCI_DEVICE,
+						 DEV_PCI_FUNCTION),
+			  dev + DEV_DATA_OFFSET);
 }
 
 static inline void dev_write(u32 dev, u32 function, u32 index, u32 value)
 {
-        pci_write(0, DEV_PCI_BUS,
-			PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
-			dev + DEV_OP_OFFSET,
-			4,
-			(u32)(((function & 0xff) << 8) + (index & 0xff)) );
+	pci_write32(DEV_PCI_BUS, PCI_DEVFN(DEV_PCI_DEVICE, DEV_PCI_FUNCTION),
+		    dev + DEV_OP_OFFSET,
+		    (u32)(((function & 0xff) << 8) + (index & 0xff)));
 
-        pci_write(0, DEV_PCI_BUS,
-			PCI_DEVFN(DEV_PCI_DEVICE,DEV_PCI_FUNCTION),
-			dev + DEV_DATA_OFFSET,
-			4, value);
+	pci_write32(DEV_PCI_BUS, PCI_DEVFN(DEV_PCI_DEVICE, DEV_PCI_FUNCTION),
+		    dev + DEV_DATA_OFFSET, value);
 }
 
 

--- a/include/pci.h
+++ b/include/pci.h
@@ -20,6 +20,8 @@
 #ifndef __PCI_H__
 #define __PCI_H__
 
+#include <boot.h>
+
 /* From include/uapi/linux/pci_regs.h */
 
 #define PCI_CONFIG_ADDR_PORT    (0x0cf8)
@@ -44,15 +46,41 @@
 #define PCI_SLOT(devfn)         (((devfn) >> 3) & 0x1f)
 #define PCI_FUNC(devfn)         ((devfn) & 0x07)
 
+extern u32 mmio_base_addr;
 
-/* From arch/x86/pci/direct.c definitions */
+#define PCI_MMIO_ADDRESS(bus, devfn, reg)			\
+	(void *)((uintptr_t)mmio_base_addr |			\
+		 ((bus) << 20) | ((devfn) << 12) | (reg))
 
-int (*pci_read)(unsigned int seg, unsigned int bus,
-		   unsigned int devfn, int reg, int len, u32 *value);
+static inline u32 pci_read8(u32 bus, u32 devfn, u32 reg)
+{
+	return ioread8(PCI_MMIO_ADDRESS(bus, devfn, reg));
+}
 
+static inline u32 pci_read16(u32 bus, u32 devfn, u32 reg)
+{
+	return ioread16(PCI_MMIO_ADDRESS(bus, devfn, reg));
+}
 
-int (*pci_write)(unsigned int seg, unsigned int bus,
-		    unsigned int devfn, int reg, int len, u32 value);
+static inline u32 pci_read32(u32 bus, u32 devfn, u32 reg)
+{
+	return ioread32(PCI_MMIO_ADDRESS(bus, devfn, reg));
+}
+
+static inline void pci_write8(u32 bus, u32 devfn, u32 reg, u32 val)
+{
+	iowrite8(PCI_MMIO_ADDRESS(bus, devfn, reg), val);
+}
+
+static inline void pci_write16(u32 bus, u32 devfn, u32 reg, u32 val)
+{
+	iowrite16(PCI_MMIO_ADDRESS(bus, devfn, reg), val);
+}
+
+static inline void pci_write32(u32 bus, u32 devfn, u32 reg, u32 val)
+{
+	iowrite32(PCI_MMIO_ADDRESS(bus, devfn, reg), val);
+}
 
 void pci_init(void);
 

--- a/pci.c
+++ b/pci.c
@@ -20,138 +20,9 @@
 
 #include <defs.h>
 #include <types.h>
-#include <errno-base.h>
-#include <boot.h>
 #include <pci.h>
 
-/*
- * Functions for accessing PCI base (first 256 bytes) and extended
- * (4096 bytes per PCI function) configuration space with type 1
- * accesses.
- */
-
-#define PCI_CONF1_ADDRESS(bus, devfn, reg) \
-        (0x80000000 | ((reg & 0xF00) << 16) | (bus << 16) \
-        | (devfn << 8) | (reg & 0xFC))
-
-static int pci_conf1_read(unsigned int seg, unsigned int bus,
-                          unsigned int devfn, int reg, int len,
-                          u32 *value)
-{
-	if (seg || (bus > 255) || (devfn > 255) || (reg > 4095))
-	{
-		*value = -1;
-		return -EINVAL;
-	}
-
-	outl(PCI_CONF1_ADDRESS(bus, devfn, reg), 0xCF8);
-
-	switch (len)
-	{
-	case 1:
-		*value = inb(0xCFC + (reg & 3));
-		break;
-	case 2:
-		*value = inw(0xCFC + (reg & 2));
-		break;
-	case 3:
-		*value = inw(0xCFC);
-		break;
-	case 4:
-		*value = inl(0xCFC);
-		break;
-	}
-
-	return 0;
-}
-
-static int pci_conf1_write(unsigned int seg, unsigned int bus,
-                           unsigned int devfn, int reg, int len,
-                           u32 value)
-{
-	if (seg || (bus > 255) || (devfn > 255) || (reg > 4095))
-		return -EINVAL;
-
-	outl(PCI_CONF1_ADDRESS(bus, devfn, reg), 0xCF8);
-
-	switch (len)
-	{
-	case 1:
-		outb((u8)value, 0xCFC + (reg & 3));
-		break;
-	case 2:
-		outw((u16)value, 0xCFC + (reg & 2));
-		break;
-	case 3:
-		outw((u16)value, 0xCFC);
-		break;
-	case 4:
-		outl((u32)value, 0xCFC);
-		break;
-	}
-
-	return 0;
-}
-
-static void *mmio_base_addr;
-
-#define PCI_MMIO_ADDRESS(bus, devfn, reg) \
-        (void *)((size_t)mmio_base_addr | (bus << 20ULL) | (devfn << 12ULL) | reg)
-
-static int pci_mmio_read(unsigned int seg, unsigned int bus,
-                   unsigned int devfn, int reg, int len, u32 *value)
-{
-	if (seg || (bus > 255) || (devfn > 255) || (reg > 4095))
-	{
-		*value = -1;
-		return -EINVAL;
-	}
-
-	void *addr = PCI_MMIO_ADDRESS(bus, devfn, reg);
-
-	switch (len)
-	{
-	case 1:
-		*value = ioread8(addr);
-		break;
-	case 2:
-		*value = ioread16((void *)((size_t)addr & ~1ULL));
-		break;
-	case 3:
-		*value = ioread16((void *)((size_t)addr & ~3ULL));
-		break;
-	case 4:
-		*value = ioread32((void *)((size_t)addr & ~3ULL));
-		break;
-	}
-	return 0;
-}
-
-static int pci_mmio_write(unsigned int seg, unsigned int bus,
-                    unsigned int devfn, int reg, int len, u32 value)
-{
-	if (seg || (bus > 255) || (devfn > 255) || (reg > 4095))
-		return -EINVAL;
-
-	void *addr = PCI_MMIO_ADDRESS(bus, devfn, reg);
-
-	switch (len)
-	{
-	case 1:
-		iowrite8(addr, (u8)value);
-		break;
-	case 2:
-		iowrite16((void *)((size_t)addr & ~1ULL), (u16)value);
-		break;
-	case 3:
-		iowrite16((void *)((size_t)addr & ~3ULL), (u16)value);
-		break;
-	case 4:
-		iowrite32((void *)((size_t)addr & ~3ULL), (u32)value);
-		break;
-	}
-	return 0;
-}
+u32 mmio_base_addr;
 
 void pci_init(void)
 {
@@ -159,15 +30,9 @@ void pci_init(void)
 
 	asm volatile("rdmsr" : "=a"(eax), "=d"(edx) : "c"(0xc0010058));
 
-	if (eax & 1)	// MMIO configuration space is enabled
-	{
-		mmio_base_addr = (void *)(((u64)edx << 32ULL) | (eax & 0xfff00000));
-		pci_read = &pci_mmio_read;
-		pci_write = &pci_mmio_write;
-	}
-	else
-	{
-		pci_read = &pci_conf1_read;
-		pci_write = &pci_conf1_write;
-	}
+	/* MMIO configuration space not enabled, or above 4G ? */
+	if (!(eax & 1) || edx)
+		die();
+
+	mmio_base_addr = eax & 0xfff00000;
 }


### PR DESCRIPTION
A number of properties of the current PCI API make it inefficient, and able to
be improved.

First of all, no return values are checked.  This makes the parameter sanity
checking logic useless.  Convert pci_write() to being void, and let pci_read()
return the value, rather than forcing it to spilled to the stack and returned
by pointer.

The seg parameter is unconditionally zero so can be dropped, and almost all
callers pass constants.  Expect callers to align their requests properly and
drop the alignment fixup logic.  Furthermore, register lengths of 3 are
nonsense.

At this point, the fact that we have two access mechanisms is forcing the use
of function pointers.  By limiting support to Fam15h and later (2011+), we can
require MMCFG and remove the cf8/cfc I/O space accessors.

The length parameter will always be a compile time constant.  Express the
helpers as static inlines with an {8,16,32} suffix for width of access.  As
most other parameters are also constant, this allows the compiler to compute
PCI_MMIO_ADDRESS() as:

  mov mmio_base_addr(%rip), %eax
  or  $0xXXXXXXXX, %eax

in the common case, with no shifting or masking at runtime.

Finally, swap mmio_base_addr from void * to u32, as it is necessarily below
the 4G boundary.  This halves the required storage and shortens the
instructions required to use it.

Overall, the resulting shrinkage is:

  add/remove: 0/6 grow/shrink: 0/7 up/down: 0/-714 (-714)
  Function                                     old     new   delta
  dev_flush_cache                               68      66      -2
  mmio_base_addr                                 8       4      -4
  pci_write                                      8       -      -8
  pci_read                                       8       -      -8
  dev_load_map                                 148     140      -8
  dev_write                                     77      56     -21
  dev_read.constprop                            83      51     -32
  pci_init                                      84      29     -55
  dev_locate                                   166      94     -72
  pci_mmio_write                               123       -    -123
  pci_mmio_read                                123       -    -123
  pci_conf1_write                              125       -    -125
  pci_conf1_read                               133       -    -133
  Total: Before=49039, After=48325, chg -1.46%

for what should be no change in behaviour.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>