### PR TITLE
build: move bootloader data out of measured block

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,8 @@ all: lz_header.bin
 # image.  One reason this might fail is if the linker decides to put an
 # unreferenced section ahead of .text, in which case link.lds needs adjusting.
 lz_header.bin: lz_header Makefile
-	objcopy -O binary -S --pad-to 0x10000 $< $@
-	@od --format=x8 --skip-bytes=4 --read-bytes=16 $@ | \
-		grep "0000004 e91192048e26f178 02ccc4765bc82a83" > /dev/null || \
-		{ echo "ERROR: LZ UUID missing or misplaced in $@" >&2; false; }
+	objcopy -O binary -S $< $@
+	@./sanity_check.sh
 
 lz_header: link.lds $(OBJ) Makefile
 	$(CC) -Wl,-T,link.lds $(LDFLAGS) $(OBJ) -o $@

--- a/extend_all.sh
+++ b/extend_all.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+. util.sh
+
+if [[ $# -ne 2 ]] || [[ ! -e "$1" ]] || [[ ! -e "$2" ]] ; then
+	echo "Usage: $0 path/to/bzImage path/to/initrd"
+	exit
+fi
+
+# see https://www.kernel.org/doc/html/latest/x86/boot.html#details-of-harder-fileds
+KERNEL_PROT_SKIP=$((`hexdump "$1" -s0x1f1 -n1 -e '/1 "%u"'` * 512 + 512))
+
+extend_sha1 "$(extend_sha1)" "`dd if="$1" bs=1 skip=$KERNEL_PROT_SKIP 2>/dev/null | sha1sum`" "$2"
+extend_sha256 "$(extend_sha256)" "`dd if="$1" bs=1 skip=$KERNEL_PROT_SKIP 2>/dev/null | sha256sum`" "$2"
+

--- a/extend_lz_only.sh
+++ b/extend_lz_only.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+. util.sh
+
+echo "Initial extensions of PCR17 after SKINIT for ${SLB_FILE}:"
+extend_sha1
+extend_sha256

--- a/head.S
+++ b/head.S
@@ -32,20 +32,9 @@
 	.section .headers, "ax", @progbits
 
 GLOBAL(sl_header)
-	.word	_entry /* SL header LZ offset to code start */
-	.word	0xffff /* SL header LZ total length */
+	.word	_entry   /* SL header LZ offset to code start */
+	.word	_sl_end  /* SL header LZ measured length */
 ENDDATA(sl_header)
-
-GLOBAL(lz_header) /* The LZ header setup by the bootloader */
-	.long	0x8e26f178 /* UUID */
-	.long	0xe9119204
-	.long	0x5bc82a83
-	.long	0x02ccc476
-	.long	0 /* Total size of Trenchboot Intermediate Loader */
-		  /* bzImage (padded out to next page) */
-	.long	0 /* Zero Page address */
-	.fill	0x14 /* MSB Key Hash */
-ENDDATA(lz_header)
 
 lz_first_stack:
 	.fill LZ_FIRST_STAGE_STACK_SIZE, 1, 0
@@ -254,3 +243,16 @@ l4_identmap: /* 1x L4 page, mapping the L3 page. 1 relocation. */
 	.align PAGE_SIZE
 ENDDATA(l4_identmap)
 #endif
+
+	.section .bootloader_data, "a", @progbits
+
+GLOBAL(lz_header) /* The LZ header setup by the bootloader */
+	.long	0x8e26f178 /* UUID */
+	.long	0xe9119204
+	.long	0x5bc82a83
+	.long	0x02ccc476
+	.long	0 /* Total size of Trenchboot Intermediate Loader */
+		  /* bzImage (padded out to next page) */
+	.long	0 /* Zero Page address */
+	.fill	0x14 /* MSB Key Hash */
+ENDDATA(lz_header)

--- a/include/defs.h
+++ b/include/defs.h
@@ -56,6 +56,7 @@
 
 /* Boot Params */
 #define BP_TB_DEV_MAP    0x0d8
+#define BP_SYSSIZE       0x1f4
 #define BP_CODE32_START  0x214
 #define BP_CMD_LINE_PTR  0x228
 #define BP_CMDLINE_SIZE  0x238

--- a/link.lds
+++ b/link.lds
@@ -48,6 +48,19 @@ SECTIONS
 		*(.page_data)
 	}
 
+	. = ALIGN(8);
+	_sl_end = .;
+
+	/*
+	 * Bootloader must pass non-constant data (e.g. address of zeropage). Keep
+	 * it in separate section, outside of measured part of SL. This must be
+	 * done in order to keep hashes constant, it also allows us to measure SL
+	 * offline.
+	 */
+	.bootloader_data : {
+		*(.bootloader_data)
+	}
+
 	_end = .;
 
 	/DISCARD/ : {

--- a/main.c
+++ b/main.c
@@ -173,7 +173,7 @@ asm_return_t lz_main(void)
 
 	/* DEV CODE */
 
-	pfn = PAGE_PFN(0x1000000 /*zero_page*/);
+	pfn = PAGE_PFN(zero_page);
 	end_pfn = PAGE_PFN(PAGE_DOWN((u8*)lz_base + 0x10000));
 
 	/* TODO: check end_pfn is not ouside of range of DEV map */
@@ -213,7 +213,7 @@ asm_return_t lz_main(void)
 	print("TPM extending ");
 	data = (u32*)(uintptr_t)*code32_start;
 	print_p(data);
-	size = lz_header.slaunch_loader_size;
+	size = (*(u32*)((u8*)zero_page + BP_SYSSIZE)) << 4;
 	sha1sum(&sha1ctx, data, size);
 	print("shasum calculated:\n");
 	hexdump(sha1ctx.buf, 20);

--- a/sanity_check.sh
+++ b/sanity_check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . util.sh
 
-od --format=x8 --skip-bytes=$SL_SIZE --read-bytes=16 $SLB_FILE | \
-	grep "e91192048e26f178 02ccc4765bc82a83" > /dev/null || \
-	{ echo "ERROR: LZ UUID missing or misplaced in $SLB_FILE" >&2; false; }
-
+if ! od --format=x8 --skip-bytes=$SL_SIZE --read-bytes=16 $SLB_FILE | grep -q "e91192048e26f178 02ccc4765bc82a83"; then
+    echo "ERROR: LZ UUID missing or misplaced in $SLB_FILE" >&2
+    false
+fi

--- a/sanity_check.sh
+++ b/sanity_check.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+. util.sh
+
+od --format=x8 --skip-bytes=$SL_SIZE --read-bytes=16 $SLB_FILE | \
+	grep "e91192048e26f178 02ccc4765bc82a83" > /dev/null || \
+	{ echo "ERROR: LZ UUID missing or misplaced in $SLB_FILE" >&2; false; }
+

--- a/util.sh
+++ b/util.sh
@@ -1,0 +1,85 @@
+SLB_FILE=${SLB_FILE:=lz_header.bin}
+
+SL_SIZE=`hexdump "$SLB_FILE" -s2 -n2 -e '/2 "%u"'`
+
+validate_and_escape_hash () {
+	local TRIM=`echo -n "$1" | sed -r -e "s/ .*//"`
+	if (( ${#TRIM} != 64 && ${#TRIM} != 40 )); then
+		>&2 echo "\"$TRIM\" is not a valid SHA1/SHA256 hash"
+		return
+	fi
+	echo -n $TRIM | sed -r -e "s/([a-f0-9]{2})/\\\\\x\1/g"
+}
+
+# extend_sha* - extend initial PCR value (all 0s) with ${FILE}'s hash (SL only)
+# extend_sha* file.bin - extend initial PCR value with full file.bin's hash
+# extend_sha* HASH file.bin - extend PCR with value=HASH with file.bin's hash
+# extend_sha* HASH1 HASH2 - extend PCR with value=HASH1 with HASH2
+# extend_sha* HASH file file...
+# extend_sha* HASH HASH HASH... - as long as file is not first
+extend_sha1 () {
+	#echo $# >&2
+	local HASH1
+	local HASH2
+	if [ $# -eq 0 ]; then
+		HASH1=`printf "0%.0s" {1..40}`
+		HASH2=`dd if="$SLB_FILE" bs=1 count=$SL_SIZE 2>/dev/null | sha1sum`
+	elif [ $# -eq 1 ]; then
+		if [ -f "$1" ]; then
+			HASH1=`printf "0%.0s" {1..40}`
+			HASH2=`dd if="$1" 2>/dev/null | sha1sum`
+		else
+			HASH1=`printf "0%.0s" {1..40}`
+			HASH2="$1"
+		fi
+	elif [ $# -eq 2 ]; then
+		if [ -f "$2" ]; then
+			HASH1="$1"
+			HASH2=`dd if="$2" 2>/dev/null | sha1sum`
+		else
+			HASH1="$1"
+			HASH2="$2"
+		fi
+	else
+		HASH1=$(extend_sha1 "$1" "$2")
+		shift 2
+		extend_sha1 "$HASH1" $@
+		return
+	fi
+	local HASH1_ESC=$(validate_and_escape_hash "$HASH1")
+	local HASH2_ESC=$(validate_and_escape_hash "$HASH2")
+	printf "%b" $HASH1_ESC $HASH2_ESC | sha1sum | sed "s/-/SHA1/"
+}
+
+extend_sha256 () {
+	local HASH1
+	local HASH2
+	if [ $# -eq 0 ]; then
+		HASH1=`printf "0%.0s" {1..64}`
+		HASH2=`dd if="$SLB_FILE" bs=1 count=$SL_SIZE 2>/dev/null | sha256sum`
+	elif [ $# -eq 1 ]; then
+		if [ -f "$1" ]; then
+			HASH1=`printf "0%.0s" {1..64}`
+			HASH2=`dd if="$1" 2>/dev/null | sha256sum`
+		else
+			HASH1=`printf "0%.0s" {1..64}`
+			HASH2="$1"
+		fi
+	elif [ $# -eq 2 ]; then
+		if [ -f "$2" ]; then
+			HASH1="$1"
+			HASH2=`dd if="$2" 2>/dev/null | sha256sum`
+		else
+			HASH1="$1"
+			HASH2="$2"
+		fi
+	else
+		HASH1=$(extend_sha256 "$1" "$2")
+		shift 2
+		extend_sha256 "$HASH1" $@
+		return
+	fi
+	local HASH1_ESC=$(validate_and_escape_hash "$HASH1")
+	local HASH2_ESC=$(validate_and_escape_hash "$HASH2")
+	printf "%b" $HASH1_ESC $HASH2_ESC | sha256sum | sed "s/-/SHA256/"
+}

--- a/util.sh
+++ b/util.sh
@@ -8,7 +8,7 @@ validate_and_escape_hash () {
 		>&2 echo "\"$TRIM\" is not a valid SHA1/SHA256 hash"
 		return
 	fi
-	echo -n $TRIM | sed -r -e "s/([a-f0-9]{2})/\\\\\x\1/g"
+	echo -n $TRIM | sed -r -e "s/([a-f0-9]{2})/\\\x\1/g"
 }
 
 # extend_sha* - extend initial PCR value (all 0s) with ${FILE}'s hash (SL only)
@@ -18,34 +18,34 @@ validate_and_escape_hash () {
 # extend_sha* HASH file file...
 # extend_sha* HASH HASH HASH... - as long as file is not first
 extend_sha1 () {
-	#echo $# >&2
 	local HASH1
 	local HASH2
-	if [ $# -eq 0 ]; then
-		HASH1=`printf "0%.0s" {1..40}`
+	case $# in
+	0)	HASH1=`printf "0%.0s" {1..40}`
 		HASH2=`dd if="$SLB_FILE" bs=1 count=$SL_SIZE 2>/dev/null | sha1sum`
-	elif [ $# -eq 1 ]; then
-		if [ -f "$1" ]; then
+		;;
+	1 )	if [ -f "$1" ]; then
 			HASH1=`printf "0%.0s" {1..40}`
 			HASH2=`dd if="$1" 2>/dev/null | sha1sum`
 		else
 			HASH1=`printf "0%.0s" {1..40}`
 			HASH2="$1"
 		fi
-	elif [ $# -eq 2 ]; then
-		if [ -f "$2" ]; then
+		;;
+	2 )	if [ -f "$2" ]; then
 			HASH1="$1"
 			HASH2=`dd if="$2" 2>/dev/null | sha1sum`
 		else
 			HASH1="$1"
 			HASH2="$2"
 		fi
-	else
-		HASH1=$(extend_sha1 "$1" "$2")
+		;;
+	* )	HASH1=$(extend_sha1 "$1" "$2")
 		shift 2
 		extend_sha1 "$HASH1" $@
 		return
-	fi
+		;;
+	esac
 	local HASH1_ESC=$(validate_and_escape_hash "$HASH1")
 	local HASH2_ESC=$(validate_and_escape_hash "$HASH2")
 	printf "%b" $HASH1_ESC $HASH2_ESC | sha1sum | sed "s/-/SHA1/"


### PR DESCRIPTION
Bootloader must fill some information about the kernel (address, size).
Those pieces of information are not constant. To keep hash values
independent of memory layout, those variables are moved to a separate
section out of SL (but still inside SLB). Length in SL header is no
longer set to maximum possible value, it points to the end of constant
data instead.

GRUB2 code must be changed accordingly.

Util for calculating initial PCR values after SKINIT is included
(calc_skinit_lz_sums.sh).

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>