### PR TITLE
build: make extern variables hidden too

### DIFF
--- a/include/boot.h
+++ b/include/boot.h
@@ -43,10 +43,6 @@ typedef struct __packed sl_header {
 	u16 lz_offet;
 	u16 lz_length;
 } sl_header_t;
-extern sl_header_t sl_header;
-
-/* The base of Landing Zone is in practice the Secure Launch header. */
-#define lz_base ((void *)&sl_header)
 
 typedef struct __packed lz_header {
 	u8  uuid[16]; /* 78 f1 26 8e 04 92 11 e9  83 2a c8 5b 76 c4 cc 02 */
@@ -54,7 +50,14 @@ typedef struct __packed lz_header {
 	u32 zero_page_addr;
 	u8  msb_key_hash[20];
 } lz_header_t;
+
+#pragma GCC visibility push(hidden)
+extern sl_header_t sl_header;
 extern lz_header_t lz_header;
+#pragma GCC visibility pop
+
+/* The base of Landing Zone is in practice the Secure Launch header. */
+#define lz_base ((void *)&sl_header)
 
 /* Fences */
 #define mb()		asm volatile("mfence" : : : "memory")

--- a/link.lds
+++ b/link.lds
@@ -48,6 +48,12 @@ SECTIONS
 		*(.page_data)
 	}
 
+	_got_start = .;
+	.got : {
+		*(.got)
+	}
+	_got_end = .;
+
 	_end = .;
 
 	/DISCARD/ : {
@@ -56,3 +62,4 @@ SECTIONS
 }
 
 ASSERT(_end <= 0x10000, "Landing Zone exceeds 64k");
+ASSERT(_got_start == _got_end, "Got GOT, extern variables used?");


### PR DESCRIPTION
Extern variables, unless specified otherwise, use default visibility
even with `-fvisibility=hidden`.

This commit fixes booting for 32b builds.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>