### PR TITLE
build: Use more hidden symbols to fix 32bit boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LDFLAGS += -flto
 endif
 
 ifeq ($(32),y)
-CFLAGS  += -m32 -fvisibility=hidden -fno-plt -freg-struct-return
+CFLAGS  += -m32 -fno-plt -freg-struct-return
 LDFLAGS += -m32
 else
 CFLAGS  += -m64

--- a/include/defs.h
+++ b/include/defs.h
@@ -17,6 +17,12 @@
 #ifndef __DEFS_H__
 #define __DEFS_H__
 
+/*
+ * All global references, including externs, need to be treated as hidden, to
+ * avoid a GOT reference in the 32bit build.
+ */
+#pragma GCC visibility push(hidden)
+
 #define PAGE_SHIFT      12
 #define PAGE_SIZE       (1 << PAGE_SHIFT)
 #define PAGE_MASK       (~(PAGE_SIZE - 1))

--- a/link.lds
+++ b/link.lds
@@ -61,6 +61,11 @@ SECTIONS
 		*(.bootloader_data)
 	}
 
+	/* This section is expected to be empty. */
+	.got : {
+		*(.got)
+	}
+
 	_end = .;
 
 	/DISCARD/ : {
@@ -69,3 +74,4 @@ SECTIONS
 }
 
 ASSERT(_end <= 0x10000, "Landing Zone exceeds 64k");
+ASSERT(SIZEOF(.got) == 0, ".got section not empty - non-hidden symbols used?");


### PR DESCRIPTION
{lz,sl}_header being non-hidden breaks the 32bit boot because of a
GOT-relative access and no dynamic linker support.

Update the GLOBAL() macro to hide each symbol (includes _entry), and have the
linker script emit a hidden symbol for _end.  This results in no GOT-relative
accesses, which fixes the 32bit boot.

Additionally, move -fvisibility=hidden to be common in the build, and check
for any global non-hidden symbols, to hopefully prevent issues like this in
the future.

Reported-by: Krystian Hebel <krystian.hebel@3mdeb.com>
Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>