### PR TITLE
Various small code-gen improvements with hashing logic

### DIFF
--- a/main.c
+++ b/main.c
@@ -28,9 +28,6 @@
 
 static u8 __page_data dev_table[3 * PAGE_SIZE];
 
-static SHA1_CONTEXT sha1ctx;
-static u8 sha256_hash[SHA256_DIGEST_SIZE];
-
 #ifdef DEBUG
 static void print_char(char c)
 {
@@ -221,12 +218,16 @@ asm_return_t lz_main(void)
 	size = (*(u32*)((u8*)zero_page + BP_SYSSIZE)) << 4;
 
 	if (tpm->family == TPM12) {
+		SHA1_CONTEXT sha1ctx;
+
 		sha1sum(&sha1ctx, data, size);
 		print("shasum calculated:\n");
 		hexdump(sha1ctx.buf, 20);
 		tpm_extend_pcr(tpm, 17, TPM_HASH_ALG_SHA1, &sha1ctx.buf[0]);
 		print("PCR extended\n");
 	} else if (tpm->family == TPM20) {
+		u8 sha256_hash[SHA256_DIGEST_SIZE];
+
 		sha256sum(sha256_hash, data, size);
 		print("shasum calculated:\n");
 		hexdump(sha256_hash, SHA256_DIGEST_SIZE);

--- a/sha1sum.c
+++ b/sha1sum.c
@@ -35,7 +35,7 @@ rol( u32 x, int n)
     return (x << n) | (x >> (-n & 31));
 }
 
-void
+static void
 sha1_init( SHA1_CONTEXT *hd )
 {
     hd->h0 = 0x67452301;

--- a/sha1sum.c
+++ b/sha1sum.c
@@ -38,13 +38,13 @@ rol( u32 x, int n)
 static void
 sha1_init( SHA1_CONTEXT *hd )
 {
-    hd->h0 = 0x67452301;
-    hd->h1 = 0xefcdab89;
-    hd->h2 = 0x98badcfe;
-    hd->h3 = 0x10325476;
-    hd->h4 = 0xc3d2e1f0;
-    hd->nblocks = 0;
-    hd->count = 0;
+    *hd = (SHA1_CONTEXT){
+        .h0 = 0x67452301,
+        .h1 = 0xefcdab89,
+        .h2 = 0x98badcfe,
+        .h3 = 0x10325476,
+        .h4 = 0xc3d2e1f0,
+    };
 }
 
 
@@ -291,8 +291,6 @@ sha1_final(SHA1_CONTEXT *hd)
 
 void sha1sum(SHA1_CONTEXT *ctx, void *ptr, u32 len)
 {
-    memset(ctx, 0, sizeof(SHA1_CONTEXT));
-
     /* TODO not sure if we can jam the entire buffer in. The original
      * code was reading the files in in 4096 chunks. Will have to try
      * it out. For now just code it the simple way. */

--- a/sha256.c
+++ b/sha256.c
@@ -218,15 +218,18 @@ static void sha256_transform(u32 *state, const u8 *input)
 
 static void sha256_init(struct sha256_state *sctx)
 {
-	sctx->state[0] = SHA256_H0;
-	sctx->state[1] = SHA256_H1;
-	sctx->state[2] = SHA256_H2;
-	sctx->state[3] = SHA256_H3;
-	sctx->state[4] = SHA256_H4;
-	sctx->state[5] = SHA256_H5;
-	sctx->state[6] = SHA256_H6;
-	sctx->state[7] = SHA256_H7;
-	sctx->count = 0;
+	*sctx = (struct sha256_state){
+		.state = {
+			SHA256_H0,
+			SHA256_H1,
+			SHA256_H2,
+			SHA256_H3,
+			SHA256_H4,
+			SHA256_H5,
+			SHA256_H6,
+			SHA256_H7,
+		},
+	};
 }
 
 static void sha256_update(struct sha256_state *sctx, const u8 *data, u32 len)
@@ -283,9 +286,8 @@ static void sha256_final(struct sha256_state *sctx, u8 *out)
 
 void sha256sum(u8 *hash, void *data, u32 len)
 {
-	struct sha256_state sctx = {};
+	struct sha256_state sctx;
 
-	memset(hash, 0, SHA256_DIGEST_SIZE);
 	sha256_init(&sctx);
 	sha256_update(&sctx, (const u8 *)data, len);
 	sha256_final(&sctx, hash);

--- a/sha256.c
+++ b/sha256.c
@@ -214,13 +214,9 @@ static void sha256_transform(u32 *state, const u8 *input)
 
 	state[0] += a; state[1] += b; state[2] += c; state[3] += d;
 	state[4] += e; state[5] += f; state[6] += g; state[7] += h;
-
-	/* clear any sensitive info... */
-	a = b = c = d = e = f = g = h = t1 = t2 = 0;
-	memset(W, 0, 16 * sizeof(u32));
 }
 
-static int sha256_init(struct sha256_state *sctx)
+static void sha256_init(struct sha256_state *sctx)
 {
 	sctx->state[0] = SHA256_H0;
 	sctx->state[1] = SHA256_H1;
@@ -231,11 +227,9 @@ static int sha256_init(struct sha256_state *sctx)
 	sctx->state[6] = SHA256_H6;
 	sctx->state[7] = SHA256_H7;
 	sctx->count = 0;
-
-	return 0;
 }
 
-static int sha256_update(struct sha256_state *sctx, const u8 *data, u32 len)
+static void sha256_update(struct sha256_state *sctx, const u8 *data, u32 len)
 {
 	unsigned int partial, done;
 	const u8 *src;
@@ -261,11 +255,9 @@ static int sha256_update(struct sha256_state *sctx, const u8 *data, u32 len)
 		partial = 0;
 	}
 	memcpy(sctx->buf + partial, src, len - done);
-
-	return 0;
 }
 
-static int sha256_final(struct sha256_state *sctx, u8 *out)
+static void sha256_final(struct sha256_state *sctx, u8 *out)
 {
 	__be32 *dst = (__be32 *)out;
 	__be64 bits;
@@ -287,11 +279,6 @@ static int sha256_final(struct sha256_state *sctx, u8 *out)
 	/* Store state in digest */
 	for (i = 0; i < 8; i++)
 		dst[i] = cpu_to_be32(sctx->state[i]);
-
-	/* Zeroize sensitive information. */
-	memset(sctx, 0, sizeof(*sctx));
-
-	return 0;
 }
 
 void sha256sum(u8 *hash, void *data, u32 len)


### PR DESCRIPTION
Net bloat-o-meter report:

```
64:
add/remove: 0/3 grow/shrink: 1/3 up/down: 26/-188 (-162)
Function                                     old     new   delta
sha1sum                                      389     415     +26
sha256_update                               7612    7610      -2
lz_main                                      269     266      -3
sha256sum                                    214     204     -10
sha256_hash                                   32       -     -32
sha1_init                                     49       -     -49
sha1ctx                                       92       -     -92
Total: Before=60531, After=60369, chg -0.27%

32:
add/remove: 0/3 grow/shrink: 1/3 up/down: 27/-214 (-187)
Function                                     old     new   delta
sha1sum                                      393     420     +27
sha256_update                               7649    7647      -2
sha256sum                                    249     235     -14
lz_main                                      292     271     -21
sha256_hash                                   32       -     -32
sha1_init                                     53       -     -53
sha1ctx                                       92       -     -92
Total: Before=31577, After=31390, chg -0.59%

lto.64:
add/remove: 2/4 grow/shrink: 0/2 up/down: 4698/-5016 (-318)
Function                                     old     new   delta
transform                                      -    4471   +4471
sha1_write                                     -     227    +227
sha256_update.lto_priv                      7902    7900      -2
sha256_hash                                   32       -     -32
sha1ctx.lto_priv                              92       -     -92
lz_main                                     1948    1818    -130
sha1_write.constprop                         256       -    -256
transform.constprop                         4504       -   -4504
Total: Before=60817, After=60499, chg -0.52%

lto.32:
add/remove: 2/4 grow/shrink: 0/2 up/down: 4250/-4548 (-298)
Function                                     old     new   delta
transform                                      -    4068   +4068
sha1_write                                     -     182    +182
sha256_update.lto_priv                      7708    7706      -2
sha256_hash                                   32       -     -32
lz_main                                     1904    1815     -89
sha1ctx.lto_priv                              92       -     -92
sha1_write.constprop                         225       -    -225
transform.constprop                         4108       -   -4108
Total: Before=31381, After=31083, chg -0.95%
```

Need to double check the stack size and possibly increase it to compensate, but it looks fine from the disassembly.