### PR TITLE
sha256: Roll iterations inside sha256_transform into loop

### DIFF
--- a/sha256.c
+++ b/sha256.c
@@ -61,6 +61,25 @@ static inline u32 BLEND_OP(u32 *W)
 	return ret;
 }
 
+const u32 K[] = {
+	0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,
+	0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+	0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,
+	0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+	0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,
+	0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+	0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,
+	0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+	0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,
+	0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+	0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,
+	0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+	0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,
+	0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+	0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,
+	0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2
+};
+
 static void sha256_transform(u32 *state, const u8 *input)
 {
 	u32 a, b, c, d, e, f, g, h, t1, t2;
@@ -76,141 +95,59 @@ static void sha256_transform(u32 *state, const u8 *input)
 	e = state[4];  f = state[5];  g = state[6];  h = state[7];
 
 	/* now iterate */
-	t1 = h + e1(e) + Ch(e, f, g) + 0x428a2f98 + W[0];
+	t1 = h + e1(e) + Ch(e, f, g) + K[0] + W[0];
 	t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1 + t2;
-	t1 = g + e1(d) + Ch(d, e, f) + 0x71374491 + W[1];
+	t1 = g + e1(d) + Ch(d, e, f) + K[1] + W[1];
 	t2 = e0(h) + Maj(h, a, b);    c += t1;    g = t1 + t2;
-	t1 = f + e1(c) + Ch(c, d, e) + 0xb5c0fbcf + W[2];
+	t1 = f + e1(c) + Ch(c, d, e) + K[2] + W[2];
 	t2 = e0(g) + Maj(g, h, a);    b += t1;    f = t1 + t2;
-	t1 = e + e1(b) + Ch(b, c, d) + 0xe9b5dba5 + W[3];
+	t1 = e + e1(b) + Ch(b, c, d) + K[3] + W[3];
 	t2 = e0(f) + Maj(f, g, h);    a += t1;    e = t1 + t2;
-	t1 = d + e1(a) + Ch(a, b, c) + 0x3956c25b + W[4];
+	t1 = d + e1(a) + Ch(a, b, c) + K[4] + W[4];
 	t2 = e0(e) + Maj(e, f, g);    h += t1;    d = t1 + t2;
-	t1 = c + e1(h) + Ch(h, a, b) + 0x59f111f1 + W[5];
+	t1 = c + e1(h) + Ch(h, a, b) + K[5] + W[5];
 	t2 = e0(d) + Maj(d, e, f);    g += t1;    c = t1 + t2;
-	t1 = b + e1(g) + Ch(g, h, a) + 0x923f82a4 + W[6];
+	t1 = b + e1(g) + Ch(g, h, a) + K[6] + W[6];
 	t2 = e0(c) + Maj(c, d, e);    f += t1;    b = t1 + t2;
-	t1 = a + e1(f) + Ch(f, g, h) + 0xab1c5ed5 + W[7];
+	t1 = a + e1(f) + Ch(f, g, h) + K[7] + W[7];
 	t2 = e0(b) + Maj(b, c, d);    e += t1;    a = t1 + t2;
 
-	t1 = h + e1(e) + Ch(e, f, g) + 0xd807aa98 + W[8];
+	t1 = h + e1(e) + Ch(e, f, g) + K[8] + W[8];
 	t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1 + t2;
-	t1 = g + e1(d) + Ch(d, e, f) + 0x12835b01 + W[9];
+	t1 = g + e1(d) + Ch(d, e, f) + K[9] + W[9];
 	t2 = e0(h) + Maj(h, a, b);    c += t1;    g = t1 + t2;
-	t1 = f + e1(c) + Ch(c, d, e) + 0x243185be + W[10];
+	t1 = f + e1(c) + Ch(c, d, e) + K[10] + W[10];
 	t2 = e0(g) + Maj(g, h, a);    b += t1;    f = t1 + t2;
-	t1 = e + e1(b) + Ch(b, c, d) + 0x550c7dc3 + W[11];
+	t1 = e + e1(b) + Ch(b, c, d) + K[11] + W[11];
 	t2 = e0(f) + Maj(f, g, h);    a += t1;    e = t1 + t2;
-	t1 = d + e1(a) + Ch(a, b, c) + 0x72be5d74 + W[12];
+	t1 = d + e1(a) + Ch(a, b, c) + K[12] + W[12];
 	t2 = e0(e) + Maj(e, f, g);    h += t1;    d = t1 + t2;
-	t1 = c + e1(h) + Ch(h, a, b) + 0x80deb1fe + W[13];
+	t1 = c + e1(h) + Ch(h, a, b) + K[13] + W[13];
 	t2 = e0(d) + Maj(d, e, f);    g += t1;    c = t1 + t2;
-	t1 = b + e1(g) + Ch(g, h, a) + 0x9bdc06a7 + W[14];
+	t1 = b + e1(g) + Ch(g, h, a) + K[14] + W[14];
 	t2 = e0(c) + Maj(c, d, e);    f += t1;    b = t1 + t2;
-	t1 = a + e1(f) + Ch(f, g, h) + 0xc19bf174 + W[15];
+	t1 = a + e1(f) + Ch(f, g, h) + K[15] + W[15];
 	t2 = e0(b) + Maj(b, c, d);    e += t1;    a = t1+t2;
 
-	t1 = h + e1(e) + Ch(e, f, g) + 0xe49b69c1 + BLEND_OP(W);
-	t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1+t2;
-	t1 = g + e1(d) + Ch(d, e, f) + 0xefbe4786 + BLEND_OP(W);
-	t2 = e0(h) + Maj(h, a, b);    c += t1;    g = t1+t2;
-	t1 = f + e1(c) + Ch(c, d, e) + 0x0fc19dc6 + BLEND_OP(W);
-	t2 = e0(g) + Maj(g, h, a);    b += t1;    f = t1+t2;
-	t1 = e + e1(b) + Ch(b, c, d) + 0x240ca1cc + BLEND_OP(W);
-	t2 = e0(f) + Maj(f, g, h);    a += t1;    e = t1+t2;
-	t1 = d + e1(a) + Ch(a, b, c) + 0x2de92c6f + BLEND_OP(W);
-	t2 = e0(e) + Maj(e, f, g);    h += t1;    d = t1+t2;
-	t1 = c + e1(h) + Ch(h, a, b) + 0x4a7484aa + BLEND_OP(W);
-	t2 = e0(d) + Maj(d, e, f);    g += t1;    c = t1+t2;
-	t1 = b + e1(g) + Ch(g, h, a) + 0x5cb0a9dc + BLEND_OP(W);
-	t2 = e0(c) + Maj(c, d, e);    f += t1;    b = t1+t2;
-	t1 = a + e1(f) + Ch(f, g, h) + 0x76f988da + BLEND_OP(W);
-	t2 = e0(b) + Maj(b, c, d);    e += t1;    a = t1+t2;
-
-	t1 = h + e1(e) + Ch(e, f, g) + 0x983e5152 + BLEND_OP(W);
-	t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1+t2;
-	t1 = g + e1(d) + Ch(d, e, f) + 0xa831c66d + BLEND_OP(W);
-	t2 = e0(h) + Maj(h, a, b);    c += t1;    g = t1+t2;
-	t1 = f + e1(c) + Ch(c, d, e) + 0xb00327c8 + BLEND_OP(W);
-	t2 = e0(g) + Maj(g, h, a);    b += t1;    f = t1+t2;
-	t1 = e + e1(b) + Ch(b, c, d) + 0xbf597fc7 + BLEND_OP(W);
-	t2 = e0(f) + Maj(f, g, h);    a += t1;    e = t1+t2;
-	t1 = d + e1(a) + Ch(a, b, c) + 0xc6e00bf3 + BLEND_OP(W);
-	t2 = e0(e) + Maj(e, f, g);    h += t1;    d = t1+t2;
-	t1 = c + e1(h) + Ch(h, a, b) + 0xd5a79147 + BLEND_OP(W);
-	t2 = e0(d) + Maj(d, e, f);    g += t1;    c = t1+t2;
-	t1 = b + e1(g) + Ch(g, h, a) + 0x06ca6351 + BLEND_OP(W);
-	t2 = e0(c) + Maj(c, d, e);    f += t1;    b = t1+t2;
-	t1 = a + e1(f) + Ch(f, g, h) + 0x14292967 + BLEND_OP(W);
-	t2 = e0(b) + Maj(b, c, d);    e += t1;    a = t1+t2;
-
-	t1 = h + e1(e) + Ch(e, f, g) + 0x27b70a85 + BLEND_OP(W);
-	t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1+t2;
-	t1 = g + e1(d) + Ch(d, e, f) + 0x2e1b2138 + BLEND_OP(W);
-	t2 = e0(h) + Maj(h, a, b);    c += t1;    g = t1+t2;
-	t1 = f + e1(c) + Ch(c, d, e) + 0x4d2c6dfc + BLEND_OP(W);
-	t2 = e0(g) + Maj(g, h, a);    b += t1;    f = t1+t2;
-	t1 = e + e1(b) + Ch(b, c, d) + 0x53380d13 + BLEND_OP(W);
-	t2 = e0(f) + Maj(f, g, h);    a += t1;    e = t1+t2;
-	t1 = d + e1(a) + Ch(a, b, c) + 0x650a7354 + BLEND_OP(W);
-	t2 = e0(e) + Maj(e, f, g);    h += t1;    d = t1+t2;
-	t1 = c + e1(h) + Ch(h, a, b) + 0x766a0abb + BLEND_OP(W);
-	t2 = e0(d) + Maj(d, e, f);    g += t1;    c = t1+t2;
-	t1 = b + e1(g) + Ch(g, h, a) + 0x81c2c92e + BLEND_OP(W);
-	t2 = e0(c) + Maj(c, d, e);    f += t1;    b = t1+t2;
-	t1 = a + e1(f) + Ch(f, g, h) + 0x92722c85 + BLEND_OP(W);
-	t2 = e0(b) + Maj(b, c, d);    e += t1;    a = t1+t2;
-
-	t1 = h + e1(e) + Ch(e, f, g) + 0xa2bfe8a1 + BLEND_OP(W);
-	t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1+t2;
-	t1 = g + e1(d) + Ch(d, e, f) + 0xa81a664b + BLEND_OP(W);
-	t2 = e0(h) + Maj(h, a, b);    c += t1;    g = t1+t2;
-	t1 = f + e1(c) + Ch(c, d, e) + 0xc24b8b70 + BLEND_OP(W);
-	t2 = e0(g) + Maj(g, h, a);    b += t1;    f = t1+t2;
-	t1 = e + e1(b) + Ch(b, c, d) + 0xc76c51a3 + BLEND_OP(W);
-	t2 = e0(f) + Maj(f, g, h);    a += t1;    e = t1+t2;
-	t1 = d + e1(a) + Ch(a, b, c) + 0xd192e819 + BLEND_OP(W);
-	t2 = e0(e) + Maj(e, f, g);    h += t1;    d = t1+t2;
-	t1 = c + e1(h) + Ch(h, a, b) + 0xd6990624 + BLEND_OP(W);
-	t2 = e0(d) + Maj(d, e, f);    g += t1;    c = t1+t2;
-	t1 = b + e1(g) + Ch(g, h, a) + 0xf40e3585 + BLEND_OP(W);
-	t2 = e0(c) + Maj(c, d, e);    f += t1;    b = t1+t2;
-	t1 = a + e1(f) + Ch(f, g, h) + 0x106aa070 + BLEND_OP(W);
-	t2 = e0(b) + Maj(b, c, d);    e += t1;    a = t1+t2;
-
-	t1 = h + e1(e) + Ch(e, f, g) + 0x19a4c116 + BLEND_OP(W);
-	t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1+t2;
-	t1 = g + e1(d) + Ch(d, e, f) + 0x1e376c08 + BLEND_OP(W);
-	t2 = e0(h) + Maj(h, a, b);    c += t1;    g = t1+t2;
-	t1 = f + e1(c) + Ch(c, d, e) + 0x2748774c + BLEND_OP(W);
-	t2 = e0(g) + Maj(g, h, a);    b += t1;    f = t1+t2;
-	t1 = e + e1(b) + Ch(b, c, d) + 0x34b0bcb5 + BLEND_OP(W);
-	t2 = e0(f) + Maj(f, g, h);    a += t1;    e = t1+t2;
-	t1 = d + e1(a) + Ch(a, b, c) + 0x391c0cb3 + BLEND_OP(W);
-	t2 = e0(e) + Maj(e, f, g);    h += t1;    d = t1+t2;
-	t1 = c + e1(h) + Ch(h, a, b) + 0x4ed8aa4a + BLEND_OP(W);
-	t2 = e0(d) + Maj(d, e, f);    g += t1;    c = t1+t2;
-	t1 = b + e1(g) + Ch(g, h, a) + 0x5b9cca4f + BLEND_OP(W);
-	t2 = e0(c) + Maj(c, d, e);    f += t1;    b = t1+t2;
-	t1 = a + e1(f) + Ch(f, g, h) + 0x682e6ff3 + BLEND_OP(W);
-	t2 = e0(b) + Maj(b, c, d);    e += t1;    a = t1+t2;
-
-	t1 = h + e1(e) + Ch(e, f, g) + 0x748f82ee + BLEND_OP(W);
-	t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1+t2;
-	t1 = g + e1(d) + Ch(d, e, f) + 0x78a5636f + BLEND_OP(W);
-	t2 = e0(h) + Maj(h, a, b);    c += t1;    g = t1+t2;
-	t1 = f + e1(c) + Ch(c, d, e) + 0x84c87814 + BLEND_OP(W);
-	t2 = e0(g) + Maj(g, h, a);    b += t1;    f = t1+t2;
-	t1 = e + e1(b) + Ch(b, c, d) + 0x8cc70208 + BLEND_OP(W);
-	t2 = e0(f) + Maj(f, g, h);    a += t1;    e = t1+t2;
-	t1 = d + e1(a) + Ch(a, b, c) + 0x90befffa + BLEND_OP(W);
-	t2 = e0(e) + Maj(e, f, g);    h += t1;    d = t1+t2;
-	t1 = c + e1(h) + Ch(h, a, b) + 0xa4506ceb + BLEND_OP(W);
-	t2 = e0(d) + Maj(d, e, f);    g += t1;    c = t1+t2;
-	t1 = b + e1(g) + Ch(g, h, a) + 0xbef9a3f7 + BLEND_OP(W);
-	t2 = e0(c) + Maj(c, d, e);    f += t1;    b = t1+t2;
-	t1 = a + e1(f) + Ch(f, g, h) + 0xc67178f2 + BLEND_OP(W);
-	t2 = e0(b) + Maj(b, c, d);    e += t1;    a = t1+t2;
+	for (i = 16; i < 64; i += 8)
+	{
+		t1 = h + e1(e) + Ch(e, f, g) + K[i] + BLEND_OP(W);
+		t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1+t2;
+		t1 = g + e1(d) + Ch(d, e, f) + K[i+1] + BLEND_OP(W);
+		t2 = e0(h) + Maj(h, a, b);    c += t1;    g = t1+t2;
+		t1 = f + e1(c) + Ch(c, d, e) + K[i+2] + BLEND_OP(W);
+		t2 = e0(g) + Maj(g, h, a);    b += t1;    f = t1+t2;
+		t1 = e + e1(b) + Ch(b, c, d) + K[i+3] + BLEND_OP(W);
+		t2 = e0(f) + Maj(f, g, h);    a += t1;    e = t1+t2;
+		t1 = d + e1(a) + Ch(a, b, c) + K[i+4] + BLEND_OP(W);
+		t2 = e0(e) + Maj(e, f, g);    h += t1;    d = t1+t2;
+		t1 = c + e1(h) + Ch(h, a, b) + K[i+5] + BLEND_OP(W);
+		t2 = e0(d) + Maj(d, e, f);    g += t1;    c = t1+t2;
+		t1 = b + e1(g) + Ch(g, h, a) + K[i+6] + BLEND_OP(W);
+		t2 = e0(c) + Maj(c, d, e);    f += t1;    b = t1+t2;
+		t1 = a + e1(f) + Ch(f, g, h) + K[i+7] + BLEND_OP(W);
+		t2 = e0(b) + Maj(b, c, d);    e += t1;    a = t1+t2;
+	}
 
 	state[0] += a; state[1] += b; state[2] += c; state[3] += d;
 	state[4] += e; state[5] += f; state[6] += g; state[7] += h;

--- a/sha256.c
+++ b/sha256.c
@@ -61,7 +61,7 @@ static inline u32 BLEND_OP(u32 *W)
 	return ret;
 }
 
-const u32 K[] = {
+static const u32 K[] = {
 	0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,
 	0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
 	0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,


### PR DESCRIPTION
64:
add/remove: 1/0 grow/shrink: 0/1 up/down: 256/-4490 (-4234)
Function                                     old     new   delta
K                                              -     256    +256
sha256_update                               7527    3037   -4490
Total: Before=60371, After=56137, chg -7.01%

32:
add/remove: 1/0 grow/shrink: 0/1 up/down: 256/-4621 (-4365)
Function                                     old     new   delta
K                                              -     256    +256
sha256_update                               7646    3025   -4621
Total: Before=31566, After=27201, chg -13.83%

Deltas are the same with and without LTO.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>