### PR TITLE
sha1: Roll iterations inside transform() into loop

### DIFF
--- a/sha1sum.c
+++ b/sha1sum.c
@@ -53,13 +53,21 @@ sha1_init( SHA1_CONTEXT *hd )
     };
 }
 
+static u32 sha1_blend(u32 *x, unsigned int i)
+{
+#define X(i) x[(i) & 15]
+
+    return X(i) = rol(X(i) ^ X(i - 14) ^ X(i - 8) ^ X(i - 3), 1);
+
+#undef X
+}
 
 /****************
  * Transform the message X which consists of 16 32-bit-words
  */
 static void sha1_transform(SHA1_CONTEXT *hd, const unsigned char *data)
 {
-    u32 a,b,c,d,e,tm;
+    u32 a,b,c,d,e;
     u32 x[16];
 
     /* get values from the chaining vars */
@@ -82,11 +90,7 @@ static void sha1_transform(SHA1_CONTEXT *hd, const unsigned char *data)
 #define F3(x,y,z)   ( ( x & y ) | ( z & ( x | y ) ) )
 #define F4(x,y,z)   ( x ^ y ^ z )
 
-
-#define M(i) ( tm =   x[i&0x0f] ^ x[(i-14)&0x0f] \
-		    ^ x[(i-8)&0x0f] ^ x[(i-3)&0x0f] \
-	       , (x[i&0x0f] = rol(tm,1)) )
-
+#define M(i) sha1_blend(x, i)
 #define R(a,b,c,d,e,f,k,m)  do { e += rol( a, 5 )     \
 				      + f( b, c, d )  \
 				      + k	      \

--- a/sha1sum.c
+++ b/sha1sum.c
@@ -69,6 +69,7 @@ static void sha1_transform(SHA1_CONTEXT *hd, const unsigned char *data)
 {
     u32 a,b,c,d,e;
     u32 x[16];
+    int i;
 
     /* get values from the chaining vars */
     a = hd->h0;
@@ -77,7 +78,7 @@ static void sha1_transform(SHA1_CONTEXT *hd, const unsigned char *data)
     d = hd->h3;
     e = hd->h4;
 
-    for (int i = 0; i < 16; ++i, data += 4)
+    for (i = 0; i < 16; ++i, data += 4)
         x[i] = cpu_to_be32(*(u32 *)data);
 
 
@@ -90,6 +91,7 @@ static void sha1_transform(SHA1_CONTEXT *hd, const unsigned char *data)
 #define F3(x,y,z)   ( ( x & y ) | ( z & ( x | y ) ) )
 #define F4(x,y,z)   ( x ^ y ^ z )
 
+
 #define M(i) sha1_blend(x, i)
 #define R(a,b,c,d,e,f,k,m)  do { e += rol( a, 5 )     \
 				      + f( b, c, d )  \
@@ -97,86 +99,44 @@ static void sha1_transform(SHA1_CONTEXT *hd, const unsigned char *data)
 				      + m;	      \
 				 b = rol( b, 30 );    \
 			       } while(0)
-    R( a, b, c, d, e, F1, K1, x[ 0] );
-    R( e, a, b, c, d, F1, K1, x[ 1] );
-    R( d, e, a, b, c, F1, K1, x[ 2] );
-    R( c, d, e, a, b, F1, K1, x[ 3] );
-    R( b, c, d, e, a, F1, K1, x[ 4] );
-    R( a, b, c, d, e, F1, K1, x[ 5] );
-    R( e, a, b, c, d, F1, K1, x[ 6] );
-    R( d, e, a, b, c, F1, K1, x[ 7] );
-    R( c, d, e, a, b, F1, K1, x[ 8] );
-    R( b, c, d, e, a, F1, K1, x[ 9] );
-    R( a, b, c, d, e, F1, K1, x[10] );
-    R( e, a, b, c, d, F1, K1, x[11] );
-    R( d, e, a, b, c, F1, K1, x[12] );
-    R( c, d, e, a, b, F1, K1, x[13] );
-    R( b, c, d, e, a, F1, K1, x[14] );
+
+    for (i = 0; i < 15; i += 5) {
+        R(a, b, c, d, e, F1, K1, x[i + 0]);
+        R(e, a, b, c, d, F1, K1, x[i + 1]);
+        R(d, e, a, b, c, F1, K1, x[i + 2]);
+        R(c, d, e, a, b, F1, K1, x[i + 3]);
+        R(b, c, d, e, a, F1, K1, x[i + 4]);
+    }
+
     R( a, b, c, d, e, F1, K1, x[15] );
     R( e, a, b, c, d, F1, K1, M(16) );
     R( d, e, a, b, c, F1, K1, M(17) );
     R( c, d, e, a, b, F1, K1, M(18) );
     R( b, c, d, e, a, F1, K1, M(19) );
-    R( a, b, c, d, e, F2, K2, M(20) );
-    R( e, a, b, c, d, F2, K2, M(21) );
-    R( d, e, a, b, c, F2, K2, M(22) );
-    R( c, d, e, a, b, F2, K2, M(23) );
-    R( b, c, d, e, a, F2, K2, M(24) );
-    R( a, b, c, d, e, F2, K2, M(25) );
-    R( e, a, b, c, d, F2, K2, M(26) );
-    R( d, e, a, b, c, F2, K2, M(27) );
-    R( c, d, e, a, b, F2, K2, M(28) );
-    R( b, c, d, e, a, F2, K2, M(29) );
-    R( a, b, c, d, e, F2, K2, M(30) );
-    R( e, a, b, c, d, F2, K2, M(31) );
-    R( d, e, a, b, c, F2, K2, M(32) );
-    R( c, d, e, a, b, F2, K2, M(33) );
-    R( b, c, d, e, a, F2, K2, M(34) );
-    R( a, b, c, d, e, F2, K2, M(35) );
-    R( e, a, b, c, d, F2, K2, M(36) );
-    R( d, e, a, b, c, F2, K2, M(37) );
-    R( c, d, e, a, b, F2, K2, M(38) );
-    R( b, c, d, e, a, F2, K2, M(39) );
-    R( a, b, c, d, e, F3, K3, M(40) );
-    R( e, a, b, c, d, F3, K3, M(41) );
-    R( d, e, a, b, c, F3, K3, M(42) );
-    R( c, d, e, a, b, F3, K3, M(43) );
-    R( b, c, d, e, a, F3, K3, M(44) );
-    R( a, b, c, d, e, F3, K3, M(45) );
-    R( e, a, b, c, d, F3, K3, M(46) );
-    R( d, e, a, b, c, F3, K3, M(47) );
-    R( c, d, e, a, b, F3, K3, M(48) );
-    R( b, c, d, e, a, F3, K3, M(49) );
-    R( a, b, c, d, e, F3, K3, M(50) );
-    R( e, a, b, c, d, F3, K3, M(51) );
-    R( d, e, a, b, c, F3, K3, M(52) );
-    R( c, d, e, a, b, F3, K3, M(53) );
-    R( b, c, d, e, a, F3, K3, M(54) );
-    R( a, b, c, d, e, F3, K3, M(55) );
-    R( e, a, b, c, d, F3, K3, M(56) );
-    R( d, e, a, b, c, F3, K3, M(57) );
-    R( c, d, e, a, b, F3, K3, M(58) );
-    R( b, c, d, e, a, F3, K3, M(59) );
-    R( a, b, c, d, e, F4, K4, M(60) );
-    R( e, a, b, c, d, F4, K4, M(61) );
-    R( d, e, a, b, c, F4, K4, M(62) );
-    R( c, d, e, a, b, F4, K4, M(63) );
-    R( b, c, d, e, a, F4, K4, M(64) );
-    R( a, b, c, d, e, F4, K4, M(65) );
-    R( e, a, b, c, d, F4, K4, M(66) );
-    R( d, e, a, b, c, F4, K4, M(67) );
-    R( c, d, e, a, b, F4, K4, M(68) );
-    R( b, c, d, e, a, F4, K4, M(69) );
-    R( a, b, c, d, e, F4, K4, M(70) );
-    R( e, a, b, c, d, F4, K4, M(71) );
-    R( d, e, a, b, c, F4, K4, M(72) );
-    R( c, d, e, a, b, F4, K4, M(73) );
-    R( b, c, d, e, a, F4, K4, M(74) );
-    R( a, b, c, d, e, F4, K4, M(75) );
-    R( e, a, b, c, d, F4, K4, M(76) );
-    R( d, e, a, b, c, F4, K4, M(77) );
-    R( c, d, e, a, b, F4, K4, M(78) );
-    R( b, c, d, e, a, F4, K4, M(79) );
+
+    for (i = 20; i < 40; i += 5) {
+        R(a, b, c, d, e, F2, K2, M(i + 0));
+        R(e, a, b, c, d, F2, K2, M(i + 1));
+        R(d, e, a, b, c, F2, K2, M(i + 2));
+        R(c, d, e, a, b, F2, K2, M(i + 3));
+        R(b, c, d, e, a, F2, K2, M(i + 4));
+    }
+
+    for (; i < 60; i += 5) {
+        R(a, b, c, d, e, F3, K3, M(i + 0));
+        R(e, a, b, c, d, F3, K3, M(i + 1));
+        R(d, e, a, b, c, F3, K3, M(i + 2));
+        R(c, d, e, a, b, F3, K3, M(i + 3));
+        R(b, c, d, e, a, F3, K3, M(i + 4));
+    }
+
+    for (; i < 80; i += 5) {
+        R(a, b, c, d, e, F4, K4, M(i + 0));
+        R(e, a, b, c, d, F4, K4, M(i + 1));
+        R(d, e, a, b, c, F4, K4, M(i + 2));
+        R(c, d, e, a, b, F4, K4, M(i + 3));
+        R(b, c, d, e, a, F4, K4, M(i + 4));
+    }
 
     /* Update chaining vars */
     hd->h0 += a;

--- a/sha1sum.c
+++ b/sha1sum.c
@@ -57,8 +57,7 @@ sha1_init( SHA1_CONTEXT *hd )
 /****************
  * Transform the message X which consists of 16 32-bit-words
  */
-static void
-transform( SHA1_CONTEXT *hd, const unsigned char *data )
+static void sha1_transform(SHA1_CONTEXT *hd, const unsigned char *data)
 {
     u32 a,b,c,d,e,tm;
     u32 x[16];
@@ -191,7 +190,7 @@ static void
 sha1_write( SHA1_CONTEXT *hd, const unsigned char *inbuf, u32 inlen)
 {
     if( hd->count == 64 ) { /* flush the buffer */
-	transform( hd, hd->buf );
+	sha1_transform(hd, hd->buf);
 	hd->count = 0;
 	hd->nblocks++;
     }
@@ -206,7 +205,7 @@ sha1_write( SHA1_CONTEXT *hd, const unsigned char *inbuf, u32 inlen)
     }
 
     while( inlen >= 64 ) {
-	transform( hd, inbuf );
+	sha1_transform(hd, inbuf);
 	hd->count = 0;
 	hd->nblocks++;
 	inlen -= 64;
@@ -256,7 +255,7 @@ sha1_final(SHA1_CONTEXT *hd, u8 hash[SHA1_DIGEST_SIZE])
     u64 *count = (void *)&hd->buf[56];
     *count = cpu_to_be64(msg_len);
 
-    transform( hd, hd->buf );
+    sha1_transform(hd, hd->buf);
 
     u32 *p = (void *)hash;
     *p++ = be32_to_cpu(hd->h0);

--- a/sha256.c
+++ b/sha256.c
@@ -100,42 +100,26 @@ static void sha256_transform(u32 *state, const u8 *input)
 	e = state[4];  f = state[5];  g = state[6];  h = state[7];
 
 	/* now iterate */
-	t1 = h + e1(e) + Ch(e, f, g) + K[0] + W[0];
-	t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1 + t2;
-	t1 = g + e1(d) + Ch(d, e, f) + K[1] + W[1];
-	t2 = e0(h) + Maj(h, a, b);    c += t1;    g = t1 + t2;
-	t1 = f + e1(c) + Ch(c, d, e) + K[2] + W[2];
-	t2 = e0(g) + Maj(g, h, a);    b += t1;    f = t1 + t2;
-	t1 = e + e1(b) + Ch(b, c, d) + K[3] + W[3];
-	t2 = e0(f) + Maj(f, g, h);    a += t1;    e = t1 + t2;
-	t1 = d + e1(a) + Ch(a, b, c) + K[4] + W[4];
-	t2 = e0(e) + Maj(e, f, g);    h += t1;    d = t1 + t2;
-	t1 = c + e1(h) + Ch(h, a, b) + K[5] + W[5];
-	t2 = e0(d) + Maj(d, e, f);    g += t1;    c = t1 + t2;
-	t1 = b + e1(g) + Ch(g, h, a) + K[6] + W[6];
-	t2 = e0(c) + Maj(c, d, e);    f += t1;    b = t1 + t2;
-	t1 = a + e1(f) + Ch(f, g, h) + K[7] + W[7];
-	t2 = e0(b) + Maj(b, c, d);    e += t1;    a = t1 + t2;
+	for (i = 0; i < 16; i += 8) {
+		t1 = h + e1(e) + Ch(e, f, g) + K[i + 0] + W[i + 0];
+		t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1 + t2;
+		t1 = g + e1(d) + Ch(d, e, f) + K[i + 1] + W[i + 1];
+		t2 = e0(h) + Maj(h, a, b);    c += t1;    g = t1 + t2;
+		t1 = f + e1(c) + Ch(c, d, e) + K[i + 2] + W[i + 2];
+		t2 = e0(g) + Maj(g, h, a);    b += t1;    f = t1 + t2;
+		t1 = e + e1(b) + Ch(b, c, d) + K[i + 3] + W[i + 3];
+		t2 = e0(f) + Maj(f, g, h);    a += t1;    e = t1 + t2;
+		t1 = d + e1(a) + Ch(a, b, c) + K[i + 4] + W[i + 4];
+		t2 = e0(e) + Maj(e, f, g);    h += t1;    d = t1 + t2;
+		t1 = c + e1(h) + Ch(h, a, b) + K[i + 5] + W[i + 5];
+		t2 = e0(d) + Maj(d, e, f);    g += t1;    c = t1 + t2;
+		t1 = b + e1(g) + Ch(g, h, a) + K[i + 6] + W[i + 6];
+		t2 = e0(c) + Maj(c, d, e);    f += t1;    b = t1 + t2;
+		t1 = a + e1(f) + Ch(f, g, h) + K[i + 7] + W[i + 7];
+		t2 = e0(b) + Maj(b, c, d);    e += t1;    a = t1 + t2;
+	}
 
-	t1 = h + e1(e) + Ch(e, f, g) + K[8] + W[8];
-	t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1 + t2;
-	t1 = g + e1(d) + Ch(d, e, f) + K[9] + W[9];
-	t2 = e0(h) + Maj(h, a, b);    c += t1;    g = t1 + t2;
-	t1 = f + e1(c) + Ch(c, d, e) + K[10] + W[10];
-	t2 = e0(g) + Maj(g, h, a);    b += t1;    f = t1 + t2;
-	t1 = e + e1(b) + Ch(b, c, d) + K[11] + W[11];
-	t2 = e0(f) + Maj(f, g, h);    a += t1;    e = t1 + t2;
-	t1 = d + e1(a) + Ch(a, b, c) + K[12] + W[12];
-	t2 = e0(e) + Maj(e, f, g);    h += t1;    d = t1 + t2;
-	t1 = c + e1(h) + Ch(h, a, b) + K[13] + W[13];
-	t2 = e0(d) + Maj(d, e, f);    g += t1;    c = t1 + t2;
-	t1 = b + e1(g) + Ch(g, h, a) + K[14] + W[14];
-	t2 = e0(c) + Maj(c, d, e);    f += t1;    b = t1 + t2;
-	t1 = a + e1(f) + Ch(f, g, h) + K[15] + W[15];
-	t2 = e0(b) + Maj(b, c, d);    e += t1;    a = t1+t2;
-
-	for (i = 16; i < 64; i += 8)
-	{
+	for (; i < 64; i += 8) {
 		t1 = h + e1(e) + Ch(e, f, g) + K[i + 0] + sha256_blend(W, i + 0);
 		t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1+t2;
 		t1 = g + e1(d) + Ch(d, e, f) + K[i + 1] + sha256_blend(W, i + 1);

--- a/sha256.c
+++ b/sha256.c
@@ -57,16 +57,13 @@ static inline void LOAD_OP(int I, u32 *W, const u8 *input)
 	W[I] = be32_to_cpu(((__be32 *)(input))[I]);
 }
 
-static inline u32 BLEND_OP(u32 *W)
+static u32 sha256_blend(u32 *W, unsigned int i)
 {
-	static unsigned i = 0;
-	u32 ret;
+#define W(i) W[(i) & 15]
 
-	W[i] = s1(W[(i-2) & 0xf]) + W[(i-7) & 0xf] + s0(W[(i-15) & 0xf]) + W[i];
-	ret = W[i];
-	i++;
-	i &= 0xf;
-	return ret;
+	return W(i) += s1(W(i - 2)) + W(i - 7) + s0(W(i - 15));
+
+#undef W
 }
 
 static const u32 K[] = {
@@ -139,21 +136,21 @@ static void sha256_transform(u32 *state, const u8 *input)
 
 	for (i = 16; i < 64; i += 8)
 	{
-		t1 = h + e1(e) + Ch(e, f, g) + K[i] + BLEND_OP(W);
+		t1 = h + e1(e) + Ch(e, f, g) + K[i + 0] + sha256_blend(W, i + 0);
 		t2 = e0(a) + Maj(a, b, c);    d += t1;    h = t1+t2;
-		t1 = g + e1(d) + Ch(d, e, f) + K[i+1] + BLEND_OP(W);
+		t1 = g + e1(d) + Ch(d, e, f) + K[i + 1] + sha256_blend(W, i + 1);
 		t2 = e0(h) + Maj(h, a, b);    c += t1;    g = t1+t2;
-		t1 = f + e1(c) + Ch(c, d, e) + K[i+2] + BLEND_OP(W);
+		t1 = f + e1(c) + Ch(c, d, e) + K[i + 2] + sha256_blend(W, i + 2);
 		t2 = e0(g) + Maj(g, h, a);    b += t1;    f = t1+t2;
-		t1 = e + e1(b) + Ch(b, c, d) + K[i+3] + BLEND_OP(W);
+		t1 = e + e1(b) + Ch(b, c, d) + K[i + 3] + sha256_blend(W, i + 3);
 		t2 = e0(f) + Maj(f, g, h);    a += t1;    e = t1+t2;
-		t1 = d + e1(a) + Ch(a, b, c) + K[i+4] + BLEND_OP(W);
+		t1 = d + e1(a) + Ch(a, b, c) + K[i + 4] + sha256_blend(W, i + 4);
 		t2 = e0(e) + Maj(e, f, g);    h += t1;    d = t1+t2;
-		t1 = c + e1(h) + Ch(h, a, b) + K[i+5] + BLEND_OP(W);
+		t1 = c + e1(h) + Ch(h, a, b) + K[i + 5] + sha256_blend(W, i + 5);
 		t2 = e0(d) + Maj(d, e, f);    g += t1;    c = t1+t2;
-		t1 = b + e1(g) + Ch(g, h, a) + K[i+6] + BLEND_OP(W);
+		t1 = b + e1(g) + Ch(g, h, a) + K[i + 6] + sha256_blend(W, i + 6);
 		t2 = e0(c) + Maj(c, d, e);    f += t1;    b = t1+t2;
-		t1 = a + e1(f) + Ch(f, g, h) + K[i+7] + BLEND_OP(W);
+		t1 = a + e1(f) + Ch(f, g, h) + K[i + 7] + sha256_blend(W, i + 7);
 		t2 = e0(b) + Maj(b, c, d);    e += t1;    a = t1+t2;
 	}
 


### PR DESCRIPTION
Use 5-round unrolled loops to keep the a..e variables consistent with
before.  The change in key schedule at round 16 is awkward, so leave
that block as it was previously.

Passing a non-constant into M() requires more brackets to produce the
correct logic, so take the opportunity to simplify it, by pulling out
the logic look up in x mod 16, and drop the temporary variable
entirely.

64:
add/remove: 0/0 grow/shrink: 0/1 up/down: 0/-2458 (-2458)
Function                                     old     new   delta
transform                                   4433    1975   -2458
Total: Before=55933, After=53475, chg -4.39%

32:
add/remove: 0/0 grow/shrink: 0/1 up/down: 0/-2140 (-2140)
Function                                     old     new   delta
transform                                   4048    1908   -2140
Total: Before=27030, After=24890, chg -7.92%

lto.64:
add/remove: 0/0 grow/shrink: 0/1 up/down: 0/-2458 (-2458)
Function                                     old     new   delta
transform                                   4433    1975   -2458
Total: Before=55466, After=53008, chg -4.43%

lto.32:
add/remove: 0/0 grow/shrink: 0/1 up/down: 0/-2140 (-2140)
Function                                     old     new   delta
transform                                   4048    1908   -2140
Total: Before=26298, After=24158, chg -8.14%

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>