### PR TITLE
Build: use -mregparm=3 for 32bit builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ LDFLAGS += -flto
 endif
 
 ifeq ($(32),y)
-CFLAGS  += -m32 -fno-plt -freg-struct-return
+CFLAGS  += -m32 -mregparm=3 -fno-plt -freg-struct-return
 LDFLAGS += -m32
 else
 CFLAGS  += -m64


### PR DESCRIPTION
This causes the first three integral function parameters to be passed in
eax/edx/ecx, rather than on the stack.

32:
add/remove: 0/0 grow/shrink: 5/25 up/down: 12/-155 (-143)
Function                                     old     new   delta
enable_tpm                                   143     150      +7
lz_main                                      264     266      +2
tpm1_pcr_extend                              241     242      +1
tis_send                                     271     272      +1
tis_request_locality                          97      98      +1
tpmb_reserve                                  36      35      -1
dev_protect_page                              26      25      -1
dev_load_map                                 164     163      -1
crb_init                                     167     166      -1
dev_locate                                   168     166      -2
crb_request_locality                         119     117      -2
tpmb_size                                      8       4      -4
tpmb_free                                     30      26      -4
tpm_relinquish_locality                       28      24      -4
dev_flush_cache                               70      66      -4
tpmb_trim                                     25      19      -6
tpmb_put                                      35      29      -6
tpm2_extend_pcr                              444     438      -6
pci_mmio_write                               146     140      -6
pci_conf1_write                              143     137      -6
pci_conf1_read                               152     146      -6
memcpy                                        28      22      -6
alloc_tpmbuff                                158     151      -7
pci_mmio_read                                147     139      -8
memset                                        23      15      -8
free_tpmbuff                                  27      19      -8
tpm_request_locality                          62      51     -11
sha256sum                                    231     218     -13
sha1sum                                      325     309     -16
tpm_extend_pcr                               241     223     -18
Total: Before=23867, After=23724, chg -0.60%

lto.32:
add/remove: 0/0 grow/shrink: 0/5 up/down: 0/-29 (-29)
Function                                     old     new   delta
lz_main                                     1616    1613      -3
pci_mmio_write                               146     140      -6
pci_conf1_write                              143     137      -6
pci_conf1_read                               152     146      -6
pci_mmio_read                                147     139      -8
Total: Before=23401, After=23372, chg -0.12%

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>