### PR TITLE
defs: use new kernel info structure

### DIFF
--- a/include/boot.h
+++ b/include/boot.h
@@ -168,7 +168,7 @@ static inline void stgi(void)
 	asm volatile(".byte 0x0f, 0x01, 0xdc" ::: "memory");
 }
 
-static inline void die(void)
+static inline void __attribute__((noreturn)) die(void)
 {
 	asm volatile("ud2");
 	unreachable();

--- a/include/linux-bootparams.h
+++ b/include/linux-bootparams.h
@@ -7,14 +7,44 @@ struct boot_params {
     u32 tb_dev_map;
     u8 _pad2[0x118];
     u32 syssize;
-    u8 _pad4[0x01c];
+    u8 _pad3[0x00e];
+    u16 version;
+    u8 _pad4[0x00c];
     u32 code32_start;
     u8 _pad6[0x010];
     u32 cmd_line_ptr;
     u8 _pad8[0x00c];
     u32 cmdline_size;
     u8 _pad10[0x02c];
-    u32 mle_header;
+    u32 kern_info_offset;
+};
+
+#define KERNEL_INFO_HEADER 0x506f544c
+
+struct kernel_info {
+    u32 header;
+    u32 size;
+    u32 size_total;
+    u32 setup_type_max;
+    u32 mle_header_offset;
+};
+
+#define MLE_UUID0	0x9082ac5a
+#define MLE_UUID1	0x74a7476f
+#define MLE_UUID2	0xa2555c0f
+#define MLE_UUID3	0x42b651cb
+struct mle_header {
+	u32 uuid[4];
+	u32 size;		/* 0x00000034 MLE header size */
+	u32 version;		/* 0x00020002 MLE version 2.2 */
+	u32 sl_stub_entry;	/* Linear entry point of MLE (virt. address) */
+	/* The following fields are used only for Intel TXT */
+	u32 first_page;		/* First valid page of MLE */
+	u32 start_offset;	/* Offset within binary of first byte of MLE */
+	u32 end_offset;		/* Offset within binary of last byte + 1 of MLE */
+	u32 vector;		/* Bit vector of MLE-supported capabilities */
+	u32 cmdline_start;	/* Starting linear address of command line */
+	u32 cmdline_end;	/* Ending linear address of command line */
 };
 
 #endif /* _LINUX_BOOTPARAMS_H */

--- a/include/linux-bootparams.h
+++ b/include/linux-bootparams.h
@@ -15,7 +15,10 @@ struct boot_params {
     u32 cmd_line_ptr;
     u8 _pad8[0x00c];
     u32 cmdline_size;
-    u8 _pad10[0x02c];
+    u8 _pad9[0x00c];
+    u32 payload_offset;
+    u32 payload_length;
+    u8 _pad10[0x018];
     u32 kern_info_offset;
 };
 

--- a/main.c
+++ b/main.c
@@ -193,10 +193,15 @@ static inline void *get_kernel_entry(struct boot_params *bp,
 	return is_in_kernel(bp, _p(bp->code32_start + mle_hdr->sl_stub_entry));
 }
 
-static void reboot(void)
+/*
+ * Even though die() has both __attribute__((noreturn)) and unreachable(),
+ * Clang still complains if it isn't repeated here.
+ */
+static void __attribute__((noreturn)) reboot(void)
 {
 	print("Rebooting now...");
 	die();
+	unreachable();
 }
 
 /*


### PR DESCRIPTION
Linux boot protocol versions 2.15+ use separate section to provide static
information about the kernel, see [1]. MLE header offset, previously found
directly in zero_page, is moved to this new structure. This patch searches
for proper address, depending on boot protocol version.

As the old way of providing MLE header offset didn't make it to upstream
kernel, it should be deprecated at some point. It is left for the time
being, as there are some other components still using it.

[1] https://01.org/linuxgraphics/gfx-docs/drm/x86/boot.html

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>