### PR TITLE
lz_main: Don't opencode boot_param accesses

### DIFF
--- a/include/defs.h
+++ b/include/defs.h
@@ -59,14 +59,9 @@
     __attribute__ ((__section__(".page_data"), __aligned__(PAGE_SIZE)))
 
 #define unreachable()   __builtin_unreachable()
+#define offsetof(a, b)  __builtin_offsetof(a, b)
 
-/* Boot Params */
-#define BP_TB_DEV_MAP    0x0d8
-#define BP_SYSSIZE       0x1f4
-#define BP_CODE32_START  0x214
-#define BP_CMD_LINE_PTR  0x228
-#define BP_CMDLINE_SIZE  0x238
-#define BP_MLE_HEADER    0x268
+#define BUILD_BUG_ON(x) ({ _Static_assert(!(x), "!(" #x ")"); })
 
 /* CRs */
 #define CR0_PE  0x00000001 /* Protected mode Enable */

--- a/include/linux-bootparams.h
+++ b/include/linux-bootparams.h
@@ -1,0 +1,20 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef _LINUX_BOOTPARAMS_H
+#define _LINUX_BOOTPARAMS_H
+
+struct boot_params {
+    u8 _pad0[0x0d8];
+    u32 tb_dev_map;
+    u8 _pad2[0x118];
+    u32 syssize;
+    u8 _pad4[0x01c];
+    u32 code32_start;
+    u8 _pad6[0x010];
+    u32 cmd_line_ptr;
+    u8 _pad8[0x00c];
+    u32 cmdline_size;
+    u8 _pad10[0x02c];
+    u32 mle_header;
+};
+
+#endif /* _LINUX_BOOTPARAMS_H */


### PR DESCRIPTION
Introduce struct boot_params and rewrite lz_main() with more normal looking C,
dropping a load of local variables in the proces.

No functional change.  Compiled code is identical (64, 64 LTO and 32), other
than the 32bit LTO case which adds one redundant reload of a stack local
variable for no obvious reason.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
---

Slightly RFC.  Is "boot_params" the correct name here?  zero_page appears to be a legacy name.