### PR TITLE
CI: Add clang tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,34 @@ _gcc_10: &_gcc_10
       packages:
         - gcc-10
 
+_clang_9: &_clang_9
+  addons:
+    apt:
+      sources:
+        - ubuntu-toolchain-r-test
+        # Work around Travis' documenation not matching the whitelist
+        # - llvm-toolchain-bionic-9
+        - sourceline: 'deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main'
+          key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+      packages:
+        - clang-9
+        - lld-9
+        - llvm-9-dev
+
+_clang_10: &_clang_10
+  addons:
+    apt:
+      sources:
+        - ubuntu-toolchain-r-test
+        # Work around Travis' documenation not matching the whitelist
+        # - llvm-toolchain-bionic-10
+        - sourceline: 'deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main'
+          key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+      packages:
+        - clang-10
+        - lld-10
+        - llvm-10-dev
+
 jobs:
   include:
     # GCC 7 tests
@@ -93,6 +121,34 @@ jobs:
     - name: GCC 10, 32bit LTO
       <<: *_gcc_10
       env: CC=gcc-10 BITS32=y LTO=y
+
+    # Clang 9 tests
+    - name: Clang 9, 64bit
+      <<: *_clang_9
+      env: CC=clang-9 BITS32=n LTO=n
+    - name: Clang 9, 64bit LTO
+      <<: *_clang_9
+      env: CC=clang-9 BITS32=n LTO=y
+    - name: Clang 9, 32bit
+      <<: *_clang_9
+      env: CC=clang-9 BITS32=y LTO=n
+    - name: Clang 9, 32bit LTO
+      <<: *_clang_9
+      env: CC=clang-9 BITS32=y LTO=y
+
+    # Clang 10 tests
+    - name: Clang 10, 64bit
+      <<: *_clang_10
+      env: CC=clang-10 BITS32=n LTO=n
+    - name: Clang 10, 64bit LTO
+      <<: *_clang_10
+      env: CC=clang-10 BITS32=n LTO=y
+    - name: Clang 10, 32bit
+      <<: *_clang_10
+      env: CC=clang-10 BITS32=y LTO=n
+    - name: Clang 10, 32bit LTO
+      <<: *_clang_10
+      env: CC=clang-10 BITS32=y LTO=y
 
 script:
   - make 32=$BITS32


### PR DESCRIPTION
This has to work around Travis' documentation not matching the whitelist of
common toolchains in the Bionic templace.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>