### PR TITLE
head: Clobber the IDT limit

### DIFF
--- a/head.S
+++ b/head.S
@@ -64,6 +64,15 @@ GLOBAL(_entry)
 	/* Set up the Stage 1 stack. */
 	lea	LZ_FIRST_STAGE_STACK_START(%ebp), %esp
 
+	/*
+	 * Clobber IDTR.limit to prevent stray interrupts/exceptions/INT from
+	 * vectoring via the IVT into unmeasured code.
+	 */
+	push	$0
+	push	$0
+	lidt	(%esp)
+	add	$8, %esp
+
 	/* Clear R_INIT and DIS_A20M.  */
 	mov	$IA32_VM_CR, %ecx
 	rdmsr


### PR DESCRIPTION
SKINIT doesn't zero IDTR.limit, meaning that an interrupt, exception or stray
INT instruction will vector via the IVT.  This is unmeasured and is a code
execution hole, which may go totally unnoticed in the common case.

Zero IDTR.limit.  This will cause any stray control flow to triple fault
rather than be silently vulnerable.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>