### PR TITLE
head: Move IDT clobbering code after segment registers are set

### DIFF
--- a/head.S
+++ b/head.S
@@ -64,15 +64,6 @@ GLOBAL(_entry)
 	/* Set up the Stage 1 stack. */
 	lea	LZ_FIRST_STAGE_STACK_START(%ebp), %esp
 
-	/*
-	 * Clobber IDTR.limit to prevent stray interrupts/exceptions/INT from
-	 * vectoring via the IVT into unmeasured code.
-	 */
-	push	$0
-	push	$0
-	lidt	(%esp)
-	add	$8, %esp
-
 	/* Clear R_INIT and DIS_A20M.  */
 	mov	$IA32_VM_CR, %ecx
 	rdmsr
@@ -98,6 +89,15 @@ GLOBAL(_entry)
 	mov	$DS_SEL, %eax
 	mov	%eax, %ds
 	mov	%eax, %es
+
+	/*
+	 * Clobber IDTR.limit to prevent stray interrupts/exceptions/INT from
+	 * vectoring via the IVT into unmeasured code.
+	 */
+	push	$0
+	push	$0
+	lidt	(%esp)
+	add	$8, %esp
 
 #ifdef __x86_64__
 	/* Restore CR4, PAE must be enabled before IA-32e mode */


### PR DESCRIPTION
Previous location resulted in triple fault on 'lidt' instruction.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>