### PR TITLE
early_tpm: use newest tpmlib revision

### DIFF
--- a/early_tpm.c
+++ b/early_tpm.c
@@ -31,54 +31,10 @@
 
 static u8 locality = TPM_NO_LOCALITY;
 
-
-static void tpm_io_delay(void)
-{
-	io_delay();
-}
-
-static void tpm_udelay(int loops)
-{
-	while (loops--)
-		tpm_io_delay();	/* Approximately 1 us */
-}
-
-/* Durations derived from Table 15 of the PTP but is purely an artifact of this
- * implementation */
-
-/* TPM Duration A: 20ms */
-static void duration_a(void)
-{
-	tpm_udelay(20000);
-}
-
-/* Timeouts defined in Table 16 of the PTP */
-
-/* TPM Timeout A: 750ms */
-static void timeout_a(void)
-{
-	tpm_udelay(750000);
-}
-
-/* TPM Timeout B: 2000ms */
-static void timeout_b(void)
-{
-	tpm_udelay(2000000);
-}
-
-/* TPM Timeout C: 200ms */
-static void timeout_c(void)
-{
-	tpm_udelay(200000);
-}
-
-/* TPM Timeout D: 30ms */
-static void timeout_d(void)
-{
-	tpm_udelay(30000);
-}
-
 /*** tpm_buff.c ***/
+
+
+#define STATIC_TIS_BUFFER_SIZE		1024
 
 #define TPM_CRB_DATA_BUFFER_OFFSET	0x80
 #define TPM_CRB_DATA_BUFFER_SIZE	3966
@@ -98,6 +54,8 @@ u8 *tpmb_reserve(struct tpmbuff *b)
 
 void tpmb_free(struct tpmbuff *b)
 {
+	memset(b->head, 0, b->len);
+
 	b->len = 0;
 	b->locked = 0;
 	b->data = NULL;
@@ -146,7 +104,6 @@ struct tpmbuff *alloc_tpmbuff(enum tpm_hw_intf intf, u8 l)
 	case TPM_DEVNODE:
 		/* TODO: need implementation */
 		goto err;
-		break;
 	case TPM_TIS:
 		if (b->head)
 			goto reset;
@@ -155,14 +112,13 @@ struct tpmbuff *alloc_tpmbuff(enum tpm_hw_intf intf, u8 l)
 		b->truesize = STATIC_TIS_BUFFER_SIZE;
 		break;
 	case TPM_CRB:
-		b->head = _p(TPM_MMIO_BASE + (l << 12) +
-			     TPM_CRB_DATA_BUFFER_OFFSET);
+		b->head = _p(TPM_MMIO_BASE + (l << 12)
+			       + TPM_CRB_DATA_BUFFER_OFFSET);
 		b->truesize = TPM_CRB_DATA_BUFFER_SIZE;
 		break;
 	case TPM_UEFI:
 		/* Not implemented yet */
 		goto err;
-		break;
 	default:
 		goto err;
 	}
@@ -202,22 +158,41 @@ void free_tpmbuff(struct tpmbuff *b, enum tpm_hw_intf intf)
 
 /*** tpmio.c ***/
 
-static u8 tpm_read8(u32 field)
+static void tpm_io_delay(void)
+{
+	io_delay();
+}
+
+static void tpm_udelay(int loops)
+{
+	while (loops--)
+		tpm_io_delay();	/* Approximately 1 us */
+}
+
+void tpm_mdelay(int ms)
+{
+	int i;
+
+	for (i = 0; i < ms; i++)
+		tpm_udelay(1000);
+}
+
+u8 tpm_read8(u32 field)
 {
 	return ioread8(_p(TPM_MMIO_BASE | field));
 }
 
-static void tpm_write8(unsigned char val, u32 field)
+void tpm_write8(unsigned char val, u32 field)
 {
 	iowrite8(_p(TPM_MMIO_BASE | field), val);
 }
 
-static u32 tpm_read32(u32 field)
+u32 tpm_read32(u32 field)
 {
 	return ioread32(_p(TPM_MMIO_BASE | field));
 }
 
-static void tpm_write32(u32 val, u32 field)
+void tpm_write32(u32 val, u32 field)
 {
 	iowrite32(_p(TPM_MMIO_BASE | field), val);
 }
@@ -225,22 +200,7 @@ static void tpm_write32(u32 val, u32 field)
 /*** tis.c ***/
 
 
-
-/* macros to access registers at locality ’’l’’ */
-#define ACCESS(l)			(0x0000 | ((l) << 12))
-#define STS(l)				(0x0018 | ((l) << 12))
-#define DATA_FIFO(l)			(0x0024 | ((l) << 12))
-#define DID_VID(l)			(0x0F00 | ((l) << 12))
-/* access bits */
-#define ACCESS_ACTIVE_LOCALITY		0x20 /* (R)*/
-#define ACCESS_RELINQUISH_LOCALITY	0x20 /* (W) */
-#define ACCESS_REQUEST_USE		0x02 /* (W) */
-/* status bits */
-#define STS_VALID			0x80 /* (R) */
-#define STS_COMMAND_READY		0x40 /* (R) */
-#define STS_DATA_AVAIL			0x10 /* (R) */
-#define STS_DATA_EXPECT			0x08 /* (R) */
-#define STS_GO				0x20 /* (W) */
+#define TPM_BURST_MIN_DELAY 100 /* 100us */
 
 
 static u32 burst_wait(void)
@@ -251,60 +211,53 @@ static u32 burst_wait(void)
 		count = tpm_read8(STS(locality) + 1);
 		count += tpm_read8(STS(locality) + 2) << 8;
 
+		/* Wait for FIFO to drain */
 		if (count == 0)
-			tpm_io_delay(); /* wait for FIFO to drain */
+			tpm_udelay(TPM_BURST_MIN_DELAY);
 	}
 
 	return count;
 }
 
+void tis_relinquish_locality(void)
+{
+	if (locality < TPM_MAX_LOCALITY)
+		tpm_write8(ACCESS_RELINQUISH_LOCALITY, ACCESS(locality));
+
+	locality = TPM_NO_LOCALITY;
+}
+
 u8 tis_request_locality(u8 l)
 {
-        if (l > TPM_MAX_LOCALITY)
-                return TPM_NO_LOCALITY;
+	if (l > TPM_MAX_LOCALITY)
+		return TPM_NO_LOCALITY;
 
 	if (l == locality)
 		return locality;
 
-        if (locality < TPM_MAX_LOCALITY) {
-                tpm_write8(ACCESS_RELINQUISH_LOCALITY, ACCESS(locality));
-                locality = TPM_NO_LOCALITY;
-        }
+	tis_relinquish_locality();
 
-        tpm_write8(ACCESS_REQUEST_USE, ACCESS(l));
+	tpm_write8(ACCESS_REQUEST_USE, ACCESS(l));
 
-        /* wait for locality to be granted */
-        if (tpm_read8(ACCESS(l)) & ACCESS_ACTIVE_LOCALITY)
-                locality = l;
+	/* wait for locality to be granted */
+	if (tpm_read8(ACCESS(l)) & ACCESS_ACTIVE_LOCALITY)
+		locality = l;
 
-        return locality;
-}
-
-void tis_relinquish_locality(void)
-{
-        if (locality < TPM_MAX_LOCALITY)
-		tpm_write8(ACCESS_RELINQUISH_LOCALITY, ACCESS(locality));
-
-        locality = TPM_NO_LOCALITY;
+	return locality;
 }
 
 u8 tis_init(struct tpm *t)
 {
-        u8 i;
+	locality = TPM_NO_LOCALITY;
 
-        for (i=0; i <= TPM_MAX_LOCALITY; i++)
-                tpm_write8(ACCESS_RELINQUISH_LOCALITY, ACCESS(i));
+	if (tis_request_locality(0) != 0)
+		return 0;
 
-        locality = TPM_NO_LOCALITY;
+	t->vendor = tpm_read32(DID_VID(0));
+	if ((t->vendor & 0xFFFF) == 0xFFFF)
+		return 0;
 
-        if (tis_request_locality(0) == TPM_NO_LOCALITY)
-                return 0;
-
-        t->vendor = tpm_read32(DID_VID(0));
-        if ((t->vendor & 0xFFFF) == 0xFFFF)
-                return 0;
-
-        return 1;
+	return 1;
 }
 
 size_t tis_send(struct tpmbuff *buf)
@@ -341,6 +294,7 @@ size_t tis_send(struct tpmbuff *buf)
 
 	/* write last byte */
 	tpm_write8(buf_ptr[buf->len - 1], DATA_FIFO(locality));
+	count++;
 
 	/* make sure it stuck */
 	for (status = 0; (status & STS_VALID) == 0; )
@@ -358,45 +312,40 @@ size_t tis_send(struct tpmbuff *buf)
 static size_t recv_data(unsigned char *buf, size_t len)
 {
 	size_t size = 0;
-	u8 status, *bufptr;
+	u8 *bufptr;
 	u32 burstcnt = 0;
 
 	bufptr = (u8 *)buf;
 
-	status = tpm_read8(STS(locality));
-	while ((status & (STS_DATA_AVAIL | STS_VALID))
-			== (STS_DATA_AVAIL | STS_VALID)
-			&& size < len) {
+	while (tis_data_available(locality) && size < len) {
 		burstcnt = burst_wait();
 		for (; burstcnt > 0 && size < len; burstcnt--) {
 			*bufptr = tpm_read8(DATA_FIFO(locality));
 			bufptr++;
 			size++;
 		}
-
-		status = tpm_read8(STS(locality));
 	}
 
 	return size;
 }
 
-size_t tis_recv(struct tpmbuff *buf)
+size_t tis_recv(enum tpm_family f, struct tpmbuff *buf)
 {
 	u32 expected;
-	u8 status, *buf_ptr;
+	u8 *buf_ptr;
 	struct tpm_header *hdr;
 
 	if (locality > TPM_MAX_LOCALITY)
 		goto err;
 
 	/* ensure that there is data available */
-	status = tpm_read8(STS(locality));
-	if ((status & (STS_DATA_AVAIL | STS_VALID))
-			!= (STS_DATA_AVAIL | STS_VALID)) {
-		timeout_d();
-		status = tpm_read8(STS(locality));
-		if ((status & (STS_DATA_AVAIL | STS_VALID))
-				!= (STS_DATA_AVAIL | STS_VALID))
+	if (!tis_data_available(locality)) {
+		if (f == TPM12)
+			tpm1_timeout_d();
+		else
+			tpm2_timeout_d();
+
+		if (!tis_data_available(locality))
 			goto err;
 	}
 
@@ -411,10 +360,14 @@ size_t tis_recv(struct tpmbuff *buf)
 	hdr->size = be32_to_cpu(hdr->size);
 	hdr->code = be32_to_cpu(hdr->code);
 
+	/* protect against integer underflow */
+	if (hdr->size <= expected)
+		goto err;
+
 	/* hdr->size = header + data */
 	expected = hdr->size - expected;
 	buf_ptr = tpmb_put(buf, expected);
-	if (! buf_ptr)
+	if (!buf_ptr)
 		goto err;
 
 	/* read all data, except last byte */
@@ -422,22 +375,16 @@ size_t tis_recv(struct tpmbuff *buf)
 		goto err;
 
 	/* check for receive underflow */
-	status = tpm_read8(STS(locality));
-	if ((status & (STS_DATA_AVAIL | STS_VALID))
-			!= (STS_DATA_AVAIL | STS_VALID))
+	if (!tis_data_available(locality))
 		goto err;
 
 	/* read last byte */
-	buf_ptr = tpmb_put(buf, 1);
 	if (recv_data(buf_ptr, 1) != 1)
 		goto err;
 
 	/* make sure we read everything */
-	status = tpm_read8(STS(locality));
-	if ((status & (STS_DATA_AVAIL | STS_VALID))
-			== (STS_DATA_AVAIL | STS_VALID)) {
+	if (tis_data_available(locality))
 		goto err;
-	}
 
 	tpm_write8(STS_COMMAND_READY, STS(locality));
 
@@ -447,7 +394,6 @@ err:
 }
 
 /*** crb.c ***/
-
 
 
 #define TPM_LOC_STATE		0x0000
@@ -468,7 +414,7 @@ err:
 #define TPM_CRB_CTRL_RSP_ADDR	0x0068
 #define TPM_CRB_DATA_BUFFER	0x0080
 
-#define REGISTER(l,r)		(((l) << 12) | (r))
+#define REGISTER(l, r)		(((l) << 12) | (r))
 
 
 struct tpm_loc_state {
@@ -544,12 +490,19 @@ static u8 is_idle(void)
 {
 	struct tpm_crb_ctrl_sts ctl_sts;
 
-	ctl_sts.val = tpm_read32(REGISTER(locality,TPM_CRB_CTRL_STS));
-	if (ctl_sts.tpm_idle == 1) {
+	ctl_sts.val = tpm_read32(REGISTER(locality, TPM_CRB_CTRL_STS));
+	if (ctl_sts.tpm_idle == 1)
 		return 1;
-	}
 
 	return 0;
+}
+
+static inline u8 is_ready(void)
+{
+	struct tpm_crb_ctrl_sts ctl_sts;
+
+	ctl_sts.val = tpm_read32(REGISTER(locality, TPM_CRB_CTRL_STS));
+	return ctl_sts.val == 0;
 }
 
 static u8 is_cmd_exec(void)
@@ -557,9 +510,8 @@ static u8 is_cmd_exec(void)
 	u32 ctrl_start;
 
 	ctrl_start = tpm_read32(REGISTER(locality, TPM_CRB_CTRL_START));
-	if (ctrl_start == 1) {
+	if (ctrl_start == 1)
 		return 1;
-	}
 
 	return 0;
 }
@@ -570,8 +522,8 @@ static u8 cmd_ready(void)
 
 	if (is_idle()) {
 		ctl_req.cmd_ready = 1;
-		tpm_write32(REGISTER(locality,TPM_CRB_CTRL_REQ), ctl_req.val);
-		timeout_c();
+		tpm_write32(ctl_req.val, REGISTER(locality, TPM_CRB_CTRL_REQ));
+		tpm2_timeout_c();
 
 		if (is_idle())
 			return -1;
@@ -588,12 +540,10 @@ static void go_idle(void)
 		return;
 
 	ctl_req.go_idle = 1;
-	tpm_write32(REGISTER(locality,TPM_CRB_CTRL_REQ), ctl_req.val);
+	tpm_write32(ctl_req.val, REGISTER(locality, TPM_CRB_CTRL_REQ));
 
 	/* pause to give tpm time to complete the request */
-	timeout_c();
-
-	return;
+	tpm2_timeout_c();
 }
 
 static void crb_relinquish_locality_internal(u16 l)
@@ -602,7 +552,7 @@ static void crb_relinquish_locality_internal(u16 l)
 
 	loc_ctrl.relinquish = 1;
 
-	tpm_write32(REGISTER(l, TPM_LOC_CTRL), loc_ctrl.val);
+	tpm_write32(loc_ctrl.val, REGISTER(l, TPM_LOC_CTRL));
 }
 
 u8 crb_request_locality(u8 l)
@@ -617,18 +567,20 @@ u8 crb_request_locality(u8 l)
 	if (loc_state.loc_assigned == 1) {
 		if (loc_state.active_locality == l) {
 			locality = l;
-                        return locality;
-                }
+			return locality;
+		}
 
 		crb_relinquish_locality_internal(loc_state.loc_assigned);
 	}
 
 	loc_ctrl.request_access = 1;
-	tpm_write32(REGISTER(l, TPM_LOC_CTRL), loc_ctrl.val);
+	tpm_write32(loc_ctrl.val, REGISTER(l, TPM_LOC_CTRL));
 
 	loc_sts.val = tpm_read32(REGISTER(l, TPM_LOC_STS));
-	if (loc_sts.granted != 1)
-		return TPM_NO_LOCALITY;
+	if (loc_sts.granted != 1) {
+		locality = TPM_NO_LOCALITY;
+		return locality;
+	}
 
 	locality = l;
 	return locality;
@@ -644,13 +596,13 @@ u8 crb_init(struct tpm *t)
 	u8 i;
 	struct tpm_crb_intf_id_ext id;
 
-	for (i=0; i<=TPM_MAX_LOCALITY; i++)
+	for (i = 0; i <= TPM_MAX_LOCALITY; i++)
 		crb_relinquish_locality_internal(i);
 
 	if (crb_request_locality(0) == TPM_NO_LOCALITY)
 		return 0;
 
-	id.val = tpm_read32(REGISTER(0,TPM_CRB_INTF_ID+4));
+	id.val = tpm_read32(REGISTER(0, TPM_CRB_INTF_ID + 4));
 	t->vendor = ((id.vid & 0x00FF) << 8) | ((id.vid & 0xFF00) >> 8);
 	if ((t->vendor & 0xFFFF) == 0xFFFF)
 		return 0;
@@ -667,10 +619,10 @@ u8 crb_init(struct tpm *t)
 static void cancel_send(void)
 {
 	if (is_cmd_exec()) {
-		tpm_write32(REGISTER(locality, TPM_CRB_CTRL_CANCEL), 1);
+		tpm_write32(1, REGISTER(locality, TPM_CRB_CTRL_CANCEL));
 		timeout_b();
 
-		tpm_write32(REGISTER(locality, TPM_CRB_CTRL_CANCEL), 0);
+		tpm_write32(0, REGISTER(locality, TPM_CRB_CTRL_CANCEL));
 	}
 }
 
@@ -681,11 +633,12 @@ size_t crb_send(struct tpmbuff *buf)
 	if (is_idle())
 		return 0;
 
-	tpm_write32(REGISTER(locality, TPM_CRB_CTRL_START), ctrl_start);
+	tpm_write32(ctrl_start, REGISTER(locality, TPM_CRB_CTRL_START));
 
-	/* most command sequences this code is interested with operates with
+	/*
+	 * Most command sequences this code is interested with operates with
 	 * 20/750 duration/timeout schedule
-	 * */
+	 */
 	duration_a();
 	ctrl_start = tpm_read32(REGISTER(locality, TPM_CRB_CTRL_START));
 	if (ctrl_start != 0) {
@@ -710,107 +663,153 @@ size_t crb_recv(struct tpmbuff *buf)
 /*** tpm1_cmds.c ***/
 
 
-
-u8 tpm1_pcr_extend(struct tpm *t, struct tpm_digest *d)
+int tpm1_pcr_extend(struct tpm *t, struct tpm_digest *d)
 {
+	int ret = 0;
 	struct tpmbuff *b = t->buff;
 	struct tpm_header *hdr;
 	struct tpm_extend_cmd *cmd;
-	struct tpm_extend_resp *resp;
+	size_t size;
 
-	if (! tpmb_reserve(b))
+	if (b == NULL) {
+		ret = -EINVAL;
 		goto out;
+	}
+
+	if (!tpmb_reserve(b)) {
+		ret = -ENOMEM;
+		goto out;
+	}
 
 	hdr = (struct tpm_header *)b->head;
 
-	hdr->tag = TPM_TAG_RQU_COMMAND;
-	hdr->code = TPM_ORD_EXTEND;
+	hdr->tag = cpu_to_be16(TPM_TAG_RQU_COMMAND);
+	hdr->code = cpu_to_be32(TPM_ORD_EXTEND);
 
 	cmd = (struct tpm_extend_cmd *)
 		tpmb_put(b, sizeof(struct tpm_extend_cmd));
-	cmd->pcr_num = d->pcr;
+	if (cmd == NULL) {
+		ret = -ENOMEM;
+		goto free;
+	}
+
+	cmd->pcr_num = cpu_to_be32(d->pcr);
 	memcpy(&(cmd->digest), &(d->digest), sizeof(TPM_DIGEST));
 
-	hdr->size = tpmb_size(b);
+	hdr->size = cpu_to_be32(tpmb_size(b));
 
 	switch (t->intf) {
 	case TPM_DEVNODE:
 		/* Not implemented yet */
+		ret = -EBADRQC;
 		break;
 	case TPM_TIS:
-		if (hdr->size != tis_send(b))
-			goto free;
+		if (be32_to_cpu(hdr->size) != tis_send(b))
+			ret = -EAGAIN;
 		break;
 	case TPM_CRB:
 		/* Not valid for TPM 1.2 */
+		ret = -ENODEV;
 		break;
 	case TPM_UEFI:
 		/* Not implemented yet */
+		ret = -EBADRQC;
 		break;
 	}
+
+	if (ret)
+		goto free;
 
 	tpmb_free(b);
 
 	/* Reset buffer for receive */
-	if (! tpmb_reserve(b))
+	if (!tpmb_reserve(b)) {
+		ret = -ENOMEM;
 		goto out;
+	}
 
 	hdr = (struct tpm_header *)b->head;
-	resp = (struct tpm_extend_resp *)
-		tpmb_put(b, sizeof(struct tpm_extend_resp));
+
+	/*
+	 * The extend receive operation returns a struct tpm_extend_resp
+	 * but the current implementation ignores the returned PCR value.
+	 */
 
 	switch (t->intf) {
 	case TPM_DEVNODE:
 		/* Not implemented yet */
+		ret = -EBADRQC;
 		break;
 	case TPM_TIS:
-		if (tpmb_size(b) != tis_recv(b))
-			goto free;
+		/* tis_recv() will increase the buffer size */
+		size = tis_recv(t->family, b);
+		if (tpmb_size(b) != size)
+			ret = -EAGAIN;
 		break;
 	case TPM_CRB:
 		/* Not valid for TPM 1.2 */
+		ret = -ENODEV;
 		break;
 	case TPM_UEFI:
 		/* Not implemented yet */
+		ret = -EBADRQC;
 		break;
 	}
 
 	tpmb_free(b);
 
-	if (resp->ordinal != TPM_SUCCESS)
+	if (ret)
 		goto out;
 
-	return 1;
+	/*
+	 * On return, the code field is used for the return code out. Though
+	 * the commands specifications section 16.1 implies there is an
+	 * ordinal field, the return size and values point to this being
+	 * incorrect.
+	 *
+	 * Also tis_recv() converts the header back to CPU endianness.
+	 */
+	if (hdr->code != TPM_SUCCESS)
+		ret = -EAGAIN;
+
+	return ret;
 free:
 	tpmb_free(b);
 out:
-	return 0;
+	return ret;
 }
 
 /*** tpm2_auth.c ***/
 
 
-
 #define NULL_AUTH_SIZE 9
 
-static u16 tpm2_null_auth_size(void)
+u32 tpm2_null_auth_size(void)
 {
 	return NULL_AUTH_SIZE;
 }
 
-static u16 tpm2_null_auth(u8 *b)
+u8 *tpm2_null_auth(struct tpmbuff *b)
 {
-	u32 *handle = (u32 *)b;
+	u32 *handle;
+	u8 *auth = (u8 *)tpmb_put(b, NULL_AUTH_SIZE);
+	if (auth == NULL)
+		goto out;
 
-	memset(b, 0, NULL_AUTH_SIZE);
+	memset(auth, 0, NULL_AUTH_SIZE);
 
+	/*
+	 * The handle, the first element, is the
+	 * only non-zero value in a NULL auth
+	 */
+	handle = (u32 *)auth;
 	*handle = cpu_to_be32(TPM_RS_PW);
 
-	return NULL_AUTH_SIZE;
+out:
+	return auth;
 }
 
 /*** tpm2_cmds.c ***/
-
 
 
 static int tpm2_alloc_cmd(struct tpmbuff *b, struct tpm2_cmd *c, u16 tag,
@@ -832,8 +831,8 @@ static u16 convert_digest_list(struct tpml_digest_values *digests)
 	u16 size = sizeof(digests->count);
 	struct tpmt_ha *h = digests->digests;
 
-	for (i=0; i<digests->count; i++) {
-		switch(h->alg) {
+	for (i = 0; i < digests->count; i++) {
+		switch (h->alg) {
 		case TPM_ALG_SHA1:
 			h->alg = cpu_to_be16(h->alg);
 			h = (struct tpmt_ha *)((u8 *)h + SHA1_SIZE);
@@ -877,24 +876,49 @@ int tpm2_extend_pcr(struct tpm *t, u32 pcr,
 	u16 size;
 	int ret = 0;
 
-	b = alloc_tpmbuff(t->intf, locality);
+	if (b == NULL) {
+		ret = -EINVAL;
+		goto out;
+	}
 
 	ret = tpm2_alloc_cmd(b, &cmd, TPM_ST_SESSIONS, TPM_CC_PCR_EXTEND);
 	if (ret < 0)
-		return ret;
+		goto out;
 
-	cmd.handles = (u32 *)tpmb_put(b, 2*sizeof(u32));
+	cmd.handles = (u32 *)tpmb_put(b, sizeof(u32));
+	if (cmd.handles == NULL) {
+		ret = -ENOMEM;
+		goto free;
+	}
+
 	cmd.handles[0] = cpu_to_be32(pcr);
 
-	cmd.auth = tpmb_put(b, tpm2_null_auth_size());
-	cmd.handles[1] = cpu_to_be32(tpm2_null_auth(cmd.auth));
+	cmd.auth_size = (u32 *)tpmb_put(b, sizeof(u32));
+	if (cmd.auth_size == NULL) {
+		ret = -ENOMEM;
+		goto free;
+	}
+
+	cmd.auth = tpm2_null_auth(b);
+	if (cmd.auth == NULL) {
+		ret = -ENOMEM;
+		goto free;
+	}
+
+	*cmd.auth_size = cpu_to_be32(tpm2_null_auth_size());
 
 	size = convert_digest_list(digests);
 	if (size == 0) {
-		tpmb_free(b);
-		return -EINVAL;
+		ret = -ENOMEM;
+		goto free;
 	}
-	cmd.params = tpmb_put(b, size);
+
+	cmd.params = (u8 *)tpmb_put(b, size);
+	if (cmd.params == NULL) {
+		ret = -ENOMEM;
+		goto free;
+	}
+
 	memcpy(cmd.params, digests, size);
 
 	cmd.header->size = cpu_to_be32(tpmb_size(b));
@@ -902,27 +926,31 @@ int tpm2_extend_pcr(struct tpm *t, u32 pcr,
 	switch (t->intf) {
 	case TPM_DEVNODE:
 		/* Not implemented yet */
+		ret = -EBADRQC;
 		break;
 	case TPM_TIS:
-		ret = tis_send(b);
+		size = tis_send(b);
+		if (tpmb_size(b) != size)
+			ret = -EAGAIN;
 		break;
 	case TPM_CRB:
-		ret = crb_send(b);
+		size = crb_send(b);
+		if (tpmb_size(b) != size)
+			ret = -EAGAIN;
 		break;
 	case TPM_UEFI:
 		/* Not implemented yet */
+		ret = -EBADRQC;
 		break;
 	}
 
-	/* TODO: check if those functions can be merged into one */
+free:
 	tpmb_free(b);
-	free_tpmbuff(b, t->intf);
-
+out:
 	return ret;
 }
 
 /*** tpm.c ***/
-
 
 
 static struct tpm tpm;
@@ -934,7 +962,7 @@ static void find_interface_and_family(struct tpm *t)
 
 	/* Sort out whether if it is 1.2 */
 	intf_cap.val = tpm_read32(TPM_INTF_CAPABILITY_0);
-	if ((intf_cap.interface_version == TPM12_TIS_INTF_12)||
+	if ((intf_cap.interface_version == TPM12_TIS_INTF_12) ||
 	    (intf_cap.interface_version == TPM12_TIS_INTF_13)) {
 		t->family = TPM12;
 		t->intf = TPM_TIS;
@@ -982,22 +1010,29 @@ err:
 	return NULL;
 }
 
-void tpm_request_locality(struct tpm *t, u8 l)
+u8 tpm_request_locality(struct tpm *t, u8 l)
 {
+	u8 ret = TPM_NO_LOCALITY;
+
 	switch (t->intf) {
 	case TPM_DEVNODE:
 		/* Not implemented yet */
 		break;
 	case TPM_TIS:
-		locality = tis_request_locality(l);
+		ret = tis_request_locality(l);
 		break;
 	case TPM_CRB:
-		locality = crb_request_locality(l);
+		ret = crb_request_locality(l);
 		break;
 	case TPM_UEFI:
 		/* Not implemented yet */
 		break;
 	}
+
+	if (ret < TPM_MAX_LOCALITY)
+		t->buff = alloc_tpmbuff(t->intf, ret);
+
+	return ret;
 }
 
 void tpm_relinquish_locality(struct tpm *t)
@@ -1016,6 +1051,8 @@ void tpm_relinquish_locality(struct tpm *t)
 		/* Not implemented yet */
 		break;
 	}
+
+	free_tpmbuff(t->buff, t->intf);
 }
 
 #define MAX_TPM_EXTEND_SIZE 70 /* TPM2 SHA512 is the largest */
@@ -1023,6 +1060,11 @@ int tpm_extend_pcr(struct tpm *t, u32 pcr, u16 algo,
 		u8 *digest)
 {
 	int ret = 0;
+
+	if (t->buff == NULL) {
+		ret = -EINVAL;
+		goto out;
+	}
 
 	if (t->family == TPM12) {
 		struct tpm_digest d;
@@ -1033,8 +1075,8 @@ int tpm_extend_pcr(struct tpm *t, u32 pcr, u16 algo,
 		}
 
 		d.pcr = pcr;
-		memcpy((void*)d.digest.sha1.digest,
-                        digest, SHA1_DIGEST_SIZE);
+		memcpy((void *)d.digest.sha1.digest,
+			digest, SHA1_DIGEST_SIZE);
 
 		ret = tpm1_pcr_extend(t, &d);
 	} else if (t->family == TPM20) {

--- a/include/errno-base.h
+++ b/include/errno-base.h
@@ -55,4 +55,7 @@
 #define	EDOM		33	/* Math argument out of domain of func */
 #define	ERANGE		34	/* Math result not representable */
 
+
+#define	EBADRQC		56	/* Invalid request code */
+
 #endif

--- a/include/tpm.h
+++ b/include/tpm.h
@@ -57,7 +57,7 @@ struct tpm {
 };
 
 struct tpm *enable_tpm(void);
-void tpm_request_locality(struct tpm *t, u8 l);
+u8 tpm_request_locality(struct tpm *t, u8 l);
 void tpm_relinquish_locality(struct tpm *t);
 int tpm_extend_pcr(struct tpm *t, u32 pcr, u16 algo,
 		u8 *digest);
@@ -83,7 +83,7 @@ void tpmb_free(struct tpmbuff *b);
 u8 *tpmb_put(struct tpmbuff *b, size_t size);
 size_t tpmb_trim(struct tpmbuff *b, size_t size);
 size_t tpmb_size(struct tpmbuff *b);
-struct tpmbuff *alloc_tpmbuff(enum tpm_hw_intf i, u8 locality);;
+struct tpmbuff *alloc_tpmbuff(enum tpm_hw_intf i, u8 locality);
 void free_tpmbuff(struct tpmbuff *b, enum tpm_hw_intf i);
 
 


### PR DESCRIPTION
Main changes:
* fixes to make TPM1.2 extend work
* corrected null auth code for TPM2
* TPM buffer is allocated and freed on locality changes, not once per cmd
* safety checks for empty buffer

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>