### PR TITLE
Event log

### DIFF
--- a/event_log.c
+++ b/event_log.c
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include <boot.h>
+#include "tpmlib/tpm.h"
+#include "tpmlib/tpm2_constants.h"
+
+static u8 *ptr_current;
+static u8 *limit;
+
+#define HAS_ENOUGH_SPACE(n)      ((limit - ptr_current) > (n))
+
+static int log_write(const void *data, unsigned size)
+{
+	if (size >= limit - ptr_current)
+		return 1;
+
+	memcpy(ptr_current, data, size);
+	ptr_current += size;
+	return 0;
+}
+
+static int strlen(const char *p)
+{
+	int count = 0;
+
+	while (*p++) count++;
+
+	return count;
+}
+
+#define EV_NO_ACTION    0x3
+/* TODO: are these types defined anywhere? */
+#define EV_TYPE_SKINIT  0x600
+#define EV_TYPE_CODE    0x601
+
+#define HASH_COUNT 2
+
+typedef struct __packed {
+	u32 pcr;
+	u32 event_type;
+	u8  digest[20];
+	u32 event_size;
+	/* u8 event[]; */
+} tpm12_event_t;
+
+typedef struct __packed {
+	char signature[16];
+	u32  platform_class;
+	u8   spec_ver_minor;
+	u8   spec_ver_major;
+	u8   errata;
+	u8   uintn_size;		/* reserved (must be 0) for 1.21 */
+} common_spec_id_ev_t;
+
+typedef struct __packed {
+	common_spec_id_ev_t c;
+	u8   vendor_info_size;
+	/* u8 vendor_info[]; */
+} tpm12_spec_id_ev_t;
+
+typedef struct __packed {
+	u32  number_of_algorithms;
+	/* Hardcode table size so we can use sizeof */
+	struct {
+		u16  id;
+		u16  size;
+	} digest_sizes[HASH_COUNT];
+} tpm20_digest_sizes_t;
+
+typedef struct __packed {
+	common_spec_id_ev_t c;
+	tpm20_digest_sizes_t sizes;
+	u8   vendor_info_size;
+	/* u8   vendor_info[]; */
+} tpm20_spec_id_ev_t;
+
+typedef struct __packed {
+	u32 pcr;
+	u32 event_type;
+	ev_log_hash_t digests;		/* defined in boot.h */
+	u32 event_size;
+	/* u8 event[]; */
+} tpm20_event_t;
+
+static const tpm12_spec_id_ev_t tpm12_id_struct = {
+	.c.signature = "Spec ID Event00",
+	.c.spec_ver_minor = 2,
+	.c.spec_ver_major = 1,
+	.c.errata = 1
+};
+
+static const tpm20_spec_id_ev_t tpm20_id_struct = {
+	.c.signature = "Spec ID Event03",
+	.c.spec_ver_minor = 0,
+	.c.spec_ver_major = 2,
+	.c.errata = 0,
+	.c.uintn_size = 2,
+	.sizes.number_of_algorithms = HASH_COUNT,
+	.sizes.digest_sizes[0].id = TPM_ALG_SHA1,
+	.sizes.digest_sizes[0].size = 20,
+	.sizes.digest_sizes[1].id = TPM_ALG_SHA256,
+	.sizes.digest_sizes[1].size = 32
+};
+
+int log_event_tpm12(u32 pcr, u8 sha1[20], char *event)
+{
+	tpm12_event_t ev;
+
+	ev.pcr = pcr;
+	ev.event_type = EV_TYPE_CODE;
+	memcpy(ev.digest, sha1, 20);
+	ev.event_size = strlen(event);
+
+	if (HAS_ENOUGH_SPACE(sizeof(ev) + ev.event_size)) {
+		log_write(&ev, sizeof(ev));
+		return log_write(event, ev.event_size);
+	}
+
+	return 1;
+}
+
+int log_event_tpm20(u32 pcr, u8 sha1[20], u8 sha256[32], char *event)
+{
+	tpm20_event_t ev;
+
+	ev.pcr = pcr;
+	ev.event_type = EV_TYPE_CODE;
+	ev.digests.count = 2;
+	ev.digests.sha1_id = TPM_ALG_SHA1;
+	memcpy(ev.digests.sha1_hash, sha1, 20);
+	ev.digests.sha256_id = TPM_ALG_SHA256;
+	memcpy(ev.digests.sha256_hash, sha256, 32);
+	ev.event_size = strlen(event);
+
+	if (HAS_ENOUGH_SPACE(sizeof(ev) + ev.event_size)) {
+		log_write(&ev, sizeof(ev));
+		return log_write(event, ev.event_size);
+	}
+
+	return 1;
+}
+
+/* TODO: make sure stack is big enough */
+int event_log_init(struct tpm *tpm)
+{
+	unsigned int min_size;
+
+	if (lz_header.event_log_addr == 0 || lz_header.event_log_size == 0)
+		goto err;
+
+	min_size = sizeof (tpm12_event_t);
+
+	if (tpm->family == TPM12) {
+		min_size += sizeof(tpm12_id_struct);
+		min_size += 2 * sizeof(tpm12_event_t); /* LZ and kernel hashes */
+	} else if (tpm->family == TPM20) {
+		min_size += sizeof(tpm20_id_struct);
+		min_size += 2 * sizeof(tpm20_event_t); /* LZ and kernel hashes */
+	} else {
+		goto err;
+	}
+
+	/* Note that min_size does not include tpmXX_event_t.event[] entries */
+	if (lz_header.event_log_size < min_size)
+		goto err;
+
+	ptr_current = _p(lz_header.event_log_addr);
+	limit = _p(lz_header.event_log_addr + lz_header.event_log_size);
+
+	/* Check for overflow */
+	if (ptr_current > limit)
+		goto err;
+
+	/*
+	 * Bootloader controls location and size, so it could force LZ to overwrite
+	 * its code **after** it was measured. Make sure that the Event Log and the
+	 * measured part of LZ do not overlap before wiping the memory.
+	 */
+	if (! ((_p(limit) < _p(_start)) || (_p(&lz_header) < _p(ptr_current))))
+		goto err;
+
+	memset(ptr_current, 0, lz_header.event_log_size);
+
+	/* Write log header */
+	{
+		tpm12_event_t ev;
+
+		ev.pcr = 0;
+		ev.event_type = EV_NO_ACTION;
+		memset(ev.digest, 0, 20);
+		if (tpm->family == TPM12) {
+			ev.event_size = sizeof(tpm12_id_struct);
+		} else {
+			ev.event_size = sizeof(tpm20_id_struct);
+		}
+
+		log_write(&ev, sizeof(ev));
+	}
+
+	if (tpm->family == TPM12) {
+		log_write(&tpm12_id_struct, sizeof(tpm12_id_struct));
+	} else {
+		log_write(&tpm20_id_struct, sizeof(tpm20_id_struct));
+	}
+
+	/* Log what was done by SKINIT */
+	if (tpm->family == TPM12) {
+		tpm12_event_t ev;
+
+		ev.pcr = 17;
+		ev.event_type = EV_TYPE_SKINIT;
+		memcpy(&ev.digest, &lz_header.lz_hashes.sha1_hash, 20);
+		ev.event_size = 0;
+
+		return log_write(&ev, sizeof(ev));
+	} else {
+		tpm20_event_t ev;
+
+		ev.pcr = 17;
+		ev.event_type = EV_TYPE_SKINIT;
+		memcpy(&ev.digests, &lz_header.lz_hashes, sizeof(ev.digests));
+		ev.event_size = 0;
+
+		return log_write(&ev, sizeof(ev));
+	}
+
+err:
+	/* Make sure that further calls to log_write() will fail */
+	limit = ptr_current;
+	return 1;
+}

--- a/head.S
+++ b/head.S
@@ -256,13 +256,22 @@ ENDDATA(l4_identmap)
 
 	.section .bootloader_data, "a", @progbits
 
-GLOBAL(lz_header) /* The LZ header setup by the bootloader */
-	.long	0x8e26f178 /* UUID */
+GLOBAL(lz_header)		/* Set up by the bootloader, keep in sync with boot.h */
+	.long	0x8e26f178	/* UUID */
 	.long	0xe9119204
 	.long	0x5bc82a83
 	.long	0x02ccc476
-	.long	0 /* Total size of Trenchboot Intermediate Loader */
-		  /* bzImage (padded out to next page) */
-	.long	0 /* Zero Page address */
-	.fill	0x14 /* MSB Key Hash */
+	.long	0			/* Total size of Trenchboot Intermediate Loader */
+						/* bzImage (padded out to next page) */
+	.long	0			/* Zero Page address */
+	.long	0			/* Event Log address */
+	.long	0			/* Event Log size */
+	.fill	0x14		/* MSB Key Hash */
+
+	/* Hashes of LZ to be written to DRTM TPM event log */
+	.long	2			/* count */
+	.word	0x0004		/* sha1_id */
+	.fill   0x14		/* sha1_hash */
+	.word	0x000B		/* sha256_id */
+	.fill   0x20		/* sha256_hash */
 ENDDATA(lz_header)

--- a/include/boot.h
+++ b/include/boot.h
@@ -47,11 +47,24 @@ typedef struct __packed sl_header {
 } sl_header_t;
 extern sl_header_t sl_header;
 
+/* The same as TPML_DIGEST_VALUES but little endian, as event log expects it */
+typedef struct __packed ev_log_hash {
+	u32 count;
+	u16 sha1_id;
+	u8 sha1_hash[20];
+	u16 sha256_id;
+	u8 sha256_hash[32];
+} ev_log_hash_t;
+
+/* Keep in sync with head.S and sanity_check.sh */
 typedef struct __packed lz_header {
 	u8  uuid[16]; /* 78 f1 26 8e 04 92 11 e9  83 2a c8 5b 76 c4 cc 02 */
 	u32 slaunch_loader_size;
 	u32 zero_page_addr;
+	u32 event_log_addr;
+	u32 event_log_size;
 	u8  msb_key_hash[20];
+	ev_log_hash_t lz_hashes;
 } lz_header_t;
 extern lz_header_t lz_header;
 

--- a/include/boot.h
+++ b/include/boot.h
@@ -42,7 +42,7 @@
 extern const char _start[];
 
 typedef struct __packed sl_header {
-	u16 lz_offet;
+	u16 lz_offset;
 	u16 lz_length;
 } sl_header_t;
 extern sl_header_t sl_header;

--- a/include/event_log.h
+++ b/include/event_log.h
@@ -1,0 +1,25 @@
+/*
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef __EVENT_LOG_H__
+#define __EVENT_LOG_H__
+
+int event_log_init(struct tpm *tpm);
+
+int log_event_tpm12(u32 pcr, u8 sha1[20], char *event);
+int log_event_tpm20(u32 pcr, u8 sha1[20], u8 sha256[32], char *event);
+
+#endif /* __EVENT_LOG_H__ */

--- a/main.c
+++ b/main.c
@@ -146,7 +146,7 @@ static void extend_pcr(struct tpm *tpm, void *data, u32 size, u32 pcr, char *ev)
 	sha1sum(hash, data, size);
 	print("shasum calculated:\n");
 	hexdump(hash, SHA1_DIGEST_SIZE);
-	tpm_extend_pcr(tpm, pcr, TPM_HASH_ALG_SHA1, hash);
+	tpm_extend_pcr(tpm, pcr, TPM_ALG_SHA1, hash);
 
 	if (tpm->family == TPM12) {
 		log_event_tpm12(pcr, hash, ev);
@@ -156,7 +156,7 @@ static void extend_pcr(struct tpm *tpm, void *data, u32 size, u32 pcr, char *ev)
 		sha256sum(sha256_hash, data, size);
 		print("shasum calculated:\n");
 		hexdump(sha256_hash, SHA256_DIGEST_SIZE);
-		tpm_extend_pcr(tpm, pcr, TPM_HASH_ALG_SHA256, &sha256_hash[0]);
+		tpm_extend_pcr(tpm, pcr, TPM_ALG_SHA256, &sha256_hash[0]);
 
 		log_event_tpm20(pcr, hash, sha256_hash, ev);
 	}
@@ -273,7 +273,8 @@ asm_return_t lz_main(void)
 	event_log_init(tpm);
 
 	/* extend TB Loader code segment into PCR17 */
-	extend_pcr(tpm, _p(bp->code32_start), bp->syssize << 4, 17, "Kernel");
+	extend_pcr(tpm, _p(bp->code32_start), bp->syssize << 4, 17,
+	           "Measured Kernel into PCR17");
 
 	tpm_relinquish_locality(tpm);
 	free_tpm(tpm);

--- a/main.c
+++ b/main.c
@@ -25,6 +25,7 @@
 #include <sha1sum.h>
 #include <sha256.h>
 #include <linux-bootparams.h>
+#include <event_log.h>
 
 #ifdef DEBUG
 static void print_char(char c)
@@ -139,25 +140,28 @@ static void print_p(const void * unused) { }
 static void hexdump(const void *unused, size_t unused2) { }
 #endif
 
-static void extend_pcr(struct tpm *tpm, void *data, u32 size, u32 pcr)
+static void extend_pcr(struct tpm *tpm, void *data, u32 size, u32 pcr, char *ev)
 {
-	if (tpm->family == TPM12) {
-		u8 hash[SHA1_DIGEST_SIZE];
+	u8 hash[SHA1_DIGEST_SIZE];
+	sha1sum(hash, data, size);
+	print("shasum calculated:\n");
+	hexdump(hash, SHA1_DIGEST_SIZE);
+	tpm_extend_pcr(tpm, pcr, TPM_HASH_ALG_SHA1, hash);
 
-		sha1sum(hash, data, size);
-		print("shasum calculated:\n");
-		hexdump(hash, SHA1_DIGEST_SIZE);
-		tpm_extend_pcr(tpm, pcr, TPM_ALG_SHA1, hash);
-		print("PCR extended\n");
+	if (tpm->family == TPM12) {
+		log_event_tpm12(pcr, hash, ev);
 	} else if (tpm->family == TPM20) {
 		u8 sha256_hash[SHA256_DIGEST_SIZE];
 
 		sha256sum(sha256_hash, data, size);
 		print("shasum calculated:\n");
 		hexdump(sha256_hash, SHA256_DIGEST_SIZE);
-		tpm_extend_pcr(tpm, pcr, TPM_ALG_SHA256, &sha256_hash[0]);
-		print("PCR extended\n");
+		tpm_extend_pcr(tpm, pcr, TPM_HASH_ALG_SHA256, &sha256_hash[0]);
+
+		log_event_tpm20(pcr, hash, sha256_hash, ev);
 	}
+
+	print("PCR extended\n");
 }
 
 /*
@@ -266,9 +270,10 @@ asm_return_t lz_main(void)
 	 */
 	tpm = enable_tpm();
 	tpm_request_locality(tpm, 2);
+	event_log_init(tpm);
 
 	/* extend TB Loader code segment into PCR17 */
-	extend_pcr(tpm, _p(bp->code32_start), bp->syssize << 4, 17);
+	extend_pcr(tpm, _p(bp->code32_start), bp->syssize << 4, 17, "Kernel");
 
 	tpm_relinquish_locality(tpm);
 	free_tpm(tpm);
@@ -280,6 +285,8 @@ asm_return_t lz_main(void)
 	hexdump(bp, 0x280);
 	print("lz_base:\n");
 	hexdump(_start, 0x100);
+	print("TPM event log:\n");
+	hexdump(_p(lz_header.event_log_addr), lz_header.event_log_size);
 
 	print("lz_main() is about to exit\n");
 

--- a/sanity_check.sh
+++ b/sanity_check.sh
@@ -4,4 +4,14 @@
 if ! od --format=x8 --skip-bytes=$SL_SIZE --read-bytes=16 $SLB_FILE | grep -q "e91192048e26f178 02ccc4765bc82a83"; then
     echo "ERROR: LZ UUID missing or misplaced in $SLB_FILE" >&2
     false
+    exit
 fi
+
+# UUID + 4 * u32 + SHA1 + u32 + u16
+SHA1_SEEK=$(($SL_SIZE + 16 + (4 * 4) + 20 + 4 + 2))
+
+# ... + SHA1 + u16
+SHA256_SEEK=$(($SHA1_SEEK + 20 + 2))
+
+dd if="$SLB_FILE" bs=1 count=$SL_SIZE 2>/dev/null | sha1sum | xxd -r -p | dd bs=1 of="$SLB_FILE" seek=$SHA1_SEEK count=20 conv=notrunc
+dd if="$SLB_FILE" bs=1 count=$SL_SIZE 2>/dev/null | sha256sum | xxd -r -p | dd bs=1 of="$SLB_FILE" seek=$SHA256_SEEK count=32 conv=notrunc


### PR DESCRIPTION
This adds support for the DRTM TPM event log, both for TPM1.2 (aka SHA1 Event
Log Entry Format [1]) and TPM2.0 (aka Crypto Agile Log Entry Format [2]).

It is up to the bootloader to provide address and size of the event log. DRTM
specification [3] defines a new ACPI table containing this information, as well
as other pointers and data related to DRTM. Bootloader may prepare and pass
another block of memory if this table is not present.

If a bootloader does not fill up the event log address or size, LZ will not log
any entries, but it will continue to extend PCRs nonetheless.

[1] https://www.trustedcomputinggroup.org/wp-content/uploads/TCG_PCClientImplementation_1-21_1_00.pdf
[2] https://trustedcomputinggroup.org/wp-content/uploads/EFI-Protocol-Specification-rev13-160330final.pdf
[3] https://trustedcomputinggroup.org/wp-content/uploads/TCG_D-RTM_Architecture_v1-0_Published_06172013.pdf