### PR TITLE
extend_all.sh: support kernels with embedded initramfs

### DIFF
--- a/extend_all.sh
+++ b/extend_all.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 . util.sh
 
-if [[ $# -ne 2 ]] || [[ ! -e "$1" ]] || [[ ! -e "$2" ]] ; then
-	echo "Usage: $0 path/to/bzImage path/to/initrd"
+if [[ $# -eq 2 ]] && [[ -e "$1" ]] && [[ -e "$2" ]] ; then
+	extend_sha1 "$sha1_zeroes" $(sha1_lz) $(sha1_kernel "$1") "$2"
+	extend_sha256 $sha256_zeroes $(sha256_lz) $(sha256_kernel "$1") "$2"
+elif [[ $# -eq 1 ]] && [[ -e "$1" ]] ; then
+	extend_sha1 $sha1_zeroes $(sha1_lz) $(sha1_kernel "$1")
+	extend_sha256 $sha256_zeroes $(sha256_lz) $(sha256_kernel "$1")
+else
+	echo "Usage: $0 path/to/bzImage [path/to/initrd]"
 	exit
 fi
 
-# see https://www.kernel.org/doc/html/latest/x86/boot.html#details-of-harder-fileds
-KERNEL_PROT_SKIP=$((`hexdump "$1" -s0x1f1 -n1 -e '/1 "%u"'` * 512 + 512))
-
-extend_sha1 "$(extend_sha1)" "`dd if="$1" bs=1 skip=$KERNEL_PROT_SKIP 2>/dev/null | sha1sum`" "$2"
-extend_sha256 "$(extend_sha256)" "`dd if="$1" bs=1 skip=$KERNEL_PROT_SKIP 2>/dev/null | sha256sum`" "$2"
 

--- a/extend_lz_only.sh
+++ b/extend_lz_only.sh
@@ -2,5 +2,5 @@
 . util.sh
 
 echo "Initial extensions of PCR17 after SKINIT for ${SLB_FILE}:"
-extend_sha1
-extend_sha256
+extend_sha1 "$sha1_zeroes" $(sha1_lz)
+extend_sha256 "$sha256_zeroes" $(sha256_lz)

--- a/util.sh
+++ b/util.sh
@@ -2,6 +2,28 @@ SLB_FILE=${SLB_FILE:=lz_header.bin}
 
 SL_SIZE=`hexdump "$SLB_FILE" -s2 -n2 -e '/2 "%u"'`
 
+sha1_zeroes=`printf "0%.0s" {1..40}`
+sha256_zeroes=`printf "0%.0s" {1..64}`
+
+# see https://www.kernel.org/doc/html/latest/x86/boot.html#details-of-header-fields
+sha1_kernel () {
+	local KERNEL_PROT_SKIP=$((`hexdump "$1" -s0x1f1 -n1 -e '/1 "%u"'` * 512 + 512))
+	dd if="$1" bs=1 skip=$KERNEL_PROT_SKIP 2>/dev/null | sha1sum | grep -o "^[a-fA-F0-9]*"
+}
+
+sha256_kernel () {
+	local KERNEL_PROT_SKIP=$((`hexdump "$1" -s0x1f1 -n1 -e '/1 "%u"'` * 512 + 512))
+	dd if="$1" bs=1 skip=$KERNEL_PROT_SKIP 2>/dev/null | sha256sum | grep -o "^[a-fA-F0-9]*"
+}
+
+sha1_lz () {
+	dd if="$SLB_FILE" bs=1 count=$SL_SIZE 2>/dev/null | sha1sum | grep -o "^[a-fA-F0-9]*"
+}
+
+sha256_lz () {
+	dd if="$SLB_FILE" bs=1 count=$SL_SIZE 2>/dev/null | sha256sum | grep -o "^[a-fA-F0-9]*"
+}
+
 validate_and_escape_hash () {
 	local TRIM=`echo -n "$1" | sed -r -e "s/ .*//"`
 	if (( ${#TRIM} != 64 && ${#TRIM} != 40 )); then
@@ -11,8 +33,6 @@ validate_and_escape_hash () {
 	echo -n $TRIM | sed -r -e "s/([a-f0-9]{2})/\\\x\1/g"
 }
 
-# extend_sha* - extend initial PCR value (all 0s) with ${FILE}'s hash (SL only)
-# extend_sha* file.bin - extend initial PCR value with full file.bin's hash
 # extend_sha* HASH file.bin - extend PCR with value=HASH with file.bin's hash
 # extend_sha* HASH1 HASH2 - extend PCR with value=HASH1 with HASH2
 # extend_sha* HASH file file...
@@ -21,16 +41,8 @@ extend_sha1 () {
 	local HASH1
 	local HASH2
 	case $# in
-	0)	HASH1=`printf "0%.0s" {1..40}`
-		HASH2=`dd if="$SLB_FILE" bs=1 count=$SL_SIZE 2>/dev/null | sha1sum`
-		;;
-	1 )	if [ -f "$1" ]; then
-			HASH1=`printf "0%.0s" {1..40}`
-			HASH2=`dd if="$1" 2>/dev/null | sha1sum`
-		else
-			HASH1=`printf "0%.0s" {1..40}`
-			HASH2="$1"
-		fi
+	[01] )	>&2 echo "extend_sha1 called with not enough arguments provided"
+		return
 		;;
 	2 )	if [ -f "$2" ]; then
 			HASH1="$1"
@@ -54,31 +66,24 @@ extend_sha1 () {
 extend_sha256 () {
 	local HASH1
 	local HASH2
-	if [ $# -eq 0 ]; then
-		HASH1=`printf "0%.0s" {1..64}`
-		HASH2=`dd if="$SLB_FILE" bs=1 count=$SL_SIZE 2>/dev/null | sha256sum`
-	elif [ $# -eq 1 ]; then
-		if [ -f "$1" ]; then
-			HASH1=`printf "0%.0s" {1..64}`
-			HASH2=`dd if="$1" 2>/dev/null | sha256sum`
-		else
-			HASH1=`printf "0%.0s" {1..64}`
-			HASH2="$1"
-		fi
-	elif [ $# -eq 2 ]; then
-		if [ -f "$2" ]; then
+	case $# in
+	[01] )	>&2 echo "extend_sha256 called with not enough arguments provided"
+		return
+		;;
+	2 )	if [ -f "$2" ]; then
 			HASH1="$1"
 			HASH2=`dd if="$2" 2>/dev/null | sha256sum`
 		else
 			HASH1="$1"
 			HASH2="$2"
 		fi
-	else
-		HASH1=$(extend_sha256 "$1" "$2")
+		;;
+	* )	HASH1=$(extend_sha256 "$1" "$2")
 		shift 2
 		extend_sha256 "$HASH1" $@
 		return
-	fi
+		;;
+	esac
 	local HASH1_ESC=$(validate_and_escape_hash "$HASH1")
 	local HASH2_ESC=$(validate_and_escape_hash "$HASH2")
 	printf "%b" $HASH1_ESC $HASH2_ESC | sha256sum | sed "s/-/SHA256/"


### PR DESCRIPTION
Modify test for number of command line arguments. For one argument,
measure the file pointed by that argument assuming it is a Linux kernel
and simulate a PCR extend operation for just the LZ and the kernel's hash.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>