### PR TITLE
Download the tpmlib submodule before running the jobs.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,7 @@
 stages:
   - build
+variables:
+  GIT_SUBMODULE_STRATEGY: recursive
 
 build_debug_disabled:
   stage: build


### PR DESCRIPTION
Previous changes add tpmlib as a submodule. The following PR fixes the
GitLab CI and provides the submodule before running the job.

Signed-off-by: Norbert Kamiński <norbert.kaminski@3mdeb.com>