### PR TITLE
iommu.c: fix order of outb() arguments

### DIFF
--- a/iommu.c
+++ b/iommu.c
@@ -29,7 +29,7 @@ static void print_char(char c)
 	while ( !(inb(0x3f8 + 5) & 0x20) )
 		;
 
-	outb(0x3f8, c);
+	outb(c, 0x3f8);
 }
 
 static void print(char * txt) {


### PR DESCRIPTION
That change was introduced with addition of tpmlib submodule in order to
make it compatible with Linux. IOMMU code was initially developed before
that, so it used the old version until now.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>