### PR TITLE
Headers Redesign

### DIFF
--- a/head.S
+++ b/head.S
@@ -32,8 +32,9 @@
 	.section .headers, "ax", @progbits
 
 GLOBAL(sl_header)
-	.word	_entry   /* SL header LZ offset to code start */
-	.word	_sl_end  /* SL header LZ measured length */
+	.word	_entry           /* SL header LZ offset to code start */
+	.word	bootloader_data  /* SL header LZ measured length */
+	.word	lz_info
 ENDDATA(sl_header)
 
 GLOBAL(lz_stack_canary)
@@ -267,18 +268,14 @@ l4_identmap: /* 1x L4 page, mapping the L3 page. 1 relocation. */
 ENDDATA(l4_identmap)
 #endif
 
-	.section .bootloader_data, "a", @progbits
-
-GLOBAL(lz_header)		/* Set up by the bootloader, keep in sync with boot.h */
+	.section .lz_info, "a", @progbits
+GLOBAL(lz_info)
 	.long	0x8e26f178	/* UUID */
 	.long	0xe9119204
 	.long	0x5bc82a83
 	.long	0x02ccc476
-boot_protocol:
-	.long	0 		/* Boot protocol used */
-	.long	0 		/* Address of the relevant structure of given protocol */
-	.long	0		/* Event Log address */
-	.long	0		/* Event Log size */
+	.long	0		/* Version */
+	.word	0		/* MSB Key Algorithm */
 	.fill	0x14		/* MSB Key Hash */
 
 	/* Hashes of LZ to be written to DRTM TPM event log */
@@ -287,4 +284,8 @@ boot_protocol:
 	.fill   0x14		/* sha1_hash */
 	.word	0x000B		/* sha256_id */
 	.fill   0x20		/* sha256_hash */
-ENDDATA(lz_header)
+ENDDATA(lz_info)
+
+	.section .bootloader_data, "a", @progbits
+GLOBAL(bootloader_data)
+	.word	0			/* Dummy data to make sure that file isn't truncated */

--- a/include/boot.h
+++ b/include/boot.h
@@ -43,10 +43,18 @@ extern const char _start[];
 extern volatile u32 lz_stack_canary;
 
 typedef struct __packed sl_header {
-	u16 lz_offset;
-	u16 lz_length;
+	u16 lz_entry_point;
+	u16 bootloader_data_offset;
+	u16 lz_info_offset;
 } sl_header_t;
 extern sl_header_t sl_header;
+
+typedef struct __packed lz_info {
+	u8  uuid[16]; /* 78 f1 26 8e 04 92 11 e9  83 2a c8 5b 76 c4 cc 02 */
+	u32 version;
+	u16 msb_key_algo;
+	u8  msb_key_hash[];
+} lz_info_t;
 
 /* The same as TPML_DIGEST_VALUES but little endian, as event log expects it */
 typedef struct __packed ev_log_hash {
@@ -59,12 +67,10 @@ typedef struct __packed ev_log_hash {
 
 /* Keep in sync with head.S and sanity_check.sh */
 typedef struct __packed lz_header {
-	u8  uuid[16]; /* 78 f1 26 8e 04 92 11 e9  83 2a c8 5b 76 c4 cc 02 */
 	u32 boot_protocol;
 	u32 proto_struct;
 	u32 event_log_addr;
 	u32 event_log_size;
-	u8  msb_key_hash[20];
 	ev_log_hash_t lz_hashes;
 } lz_header_t;
 extern lz_header_t lz_header;

--- a/include/defs.h
+++ b/include/defs.h
@@ -23,10 +23,10 @@
  */
 #pragma GCC visibility push(hidden)
 
-#define LINUX_BOOT	0
-#define MULTIBOOT2	2
+#define LINUX_BOOT      0
+#define MULTIBOOT2      2
 
-#define STACK_CANARY	0xDEADBEEF
+#define STACK_CANARY    0xDEADBEEF
 
 #define PAGE_SHIFT      12
 #define PAGE_SIZE       (1 << PAGE_SHIFT)
@@ -36,6 +36,7 @@
 #define PAGE_PFN(p)     ((uintptr_t)(p) >> PAGE_SHIFT)
 
 #define GIGABYTE    0x40000000
+#define SLB_SIZE    0x10000
 
 #define _u(x) ((uintptr_t)(x))
 #define _p(x) ((void *)_u(x))

--- a/include/tags.h
+++ b/include/tags.h
@@ -1,0 +1,94 @@
+#ifndef __TAGS_H__
+#define __TAGS_H__
+
+#include <defs.h>
+#include <types.h>
+
+#define LZ_TAG_CLASS_MASK	0xF0
+
+/* Tags with no particular class */
+#define LZ_TAG_NO_CLASS		0x00
+#define LZ_TAG_END		0x00
+#define LZ_TAG_UNAWARE_OS	0x01
+#define LZ_TAG_TAGS_SIZE	0x0F	/* Always first */
+
+/* Tags specifying kernel type */
+#define LZ_TAG_BOOT_CLASS	0x10
+#define LZ_TAG_BOOT_LINUX	0x10
+#define LZ_TAG_BOOT_MB2		0x11
+
+/* Tags specific to TPM event log */
+#define LZ_TAG_EVENT_LOG_CLASS	0x20
+#define LZ_TAG_EVENT_LOG	0x20
+#define LZ_TAG_LZ_HASH		0x21
+
+struct lz_tag_hdr {
+	u8 type;
+	u8 len;
+} __packed;
+
+struct lz_tag_tags_size {
+	struct lz_tag_hdr hdr;
+	u16 size;
+} __packed;
+
+struct lz_tag_boot_linux {
+	struct lz_tag_hdr hdr;
+	u32 zero_page;
+} __packed;
+
+struct lz_tag_boot_mb2 {
+	struct lz_tag_hdr hdr;
+	u32 mbi;
+	u32 kernel_entry;
+	u32 kernel_size;
+} __packed;
+
+struct lz_tag_evtlog {
+	struct lz_tag_hdr hdr;
+	u32 address;
+	u32 size;
+} __packed;
+
+struct lz_tag_hash {
+	struct lz_tag_hdr hdr;
+	u16 algo_id;
+	u8 digest[];
+} __packed;
+
+extern struct lz_tag_tags_size bootloader_data;
+
+static inline void* end_of_tags(void)
+{
+	return (((void *) &bootloader_data) + bootloader_data.size);
+}
+
+static inline void* next_tag(void* t)
+{
+	void *x = t + ((struct lz_tag_hdr*)t)->len;
+	return x < end_of_tags() ? x : NULL;
+}
+
+static inline void* next_of_type(void* _t, u8 type)
+{
+	struct lz_tag_hdr *t = _t;
+	while (t->type != LZ_TAG_END) {
+		t = next_tag(t);
+		if (t->type == type)
+			return (void*)t < end_of_tags() ? t : NULL;
+	}
+	return NULL;
+}
+
+static inline void* next_of_class(void* _t, u8 c)
+{
+	struct lz_tag_hdr *t = _t;
+	while (t->type != LZ_TAG_END) {
+		t = next_tag(t);
+		if ((t->type & LZ_TAG_CLASS_MASK) == c)
+			return (void*)t < end_of_tags() ? t : NULL;
+	}
+	return NULL;
+}
+
+#endif /* __TAGS_H__ */

--- a/link.lds
+++ b/link.lds
@@ -49,8 +49,11 @@ SECTIONS
 		*(.page_data)
 	}
 
+	.lz_info : {
+		*(.lz_info)
+	}
+
 	. = ALIGN(8);
-	_sl_end = .;
 
 	/*
 	 * Bootloader must pass non-constant data (e.g. address of zeropage). Keep

--- a/sanity_check.sh
+++ b/sanity_check.sh
@@ -1,17 +1,9 @@
 #!/bin/bash
 . util.sh
 
-if ! od --format=x8 --skip-bytes=$SL_SIZE --read-bytes=16 $SLB_FILE | grep -q "e91192048e26f178 02ccc4765bc82a83"; then
+LZ_INFO=`hexdump "$SLB_FILE" -s4 -n2 -e '/2 "%u"'`
+
+if ! od --format=x8 --skip-bytes=$LZ_INFO --read-bytes=16 $SLB_FILE | grep -q "e91192048e26f178 02ccc4765bc82a83"; then
     echo "ERROR: LZ UUID missing or misplaced in $SLB_FILE" >&2
     false
-    exit
 fi
-
-# UUID + 4 * u32 + SHA1 + u32 + u16
-SHA1_SEEK=$(($SL_SIZE + 16 + (4 * 4) + 20 + 4 + 2))
-
-# ... + SHA1 + u16
-SHA256_SEEK=$(($SHA1_SEEK + 20 + 2))
-
-dd if="$SLB_FILE" bs=1 count=$SL_SIZE 2>/dev/null | sha1sum | xxd -r -p | dd bs=1 of="$SLB_FILE" seek=$SHA1_SEEK count=20 conv=notrunc
-dd if="$SLB_FILE" bs=1 count=$SL_SIZE 2>/dev/null | sha256sum | xxd -r -p | dd bs=1 of="$SLB_FILE" seek=$SHA256_SEEK count=32 conv=notrunc


### PR DESCRIPTION
This is a resubmittal of PR #56.

This patch was created mainly to deal with compatibility issues between
bootloader and Landing Zone appearing after every feature added. It should
give the possibility to add more pieces of information passed from the
bootloader in the future without breaking booting of older versions of LZ,
starting with this one.

Also, from now on it is the bootloader's task to calculate and pass the LZ
hash(es), there are no longer precalculated and included in the file.

Signed-off-by: Krystian Hebel <krystian.hebel@3mdeb.com>