### PR TITLE
Optimise strlen() using __builtin_strlen()

### DIFF
--- a/event_log.c
+++ b/event_log.c
@@ -36,15 +36,6 @@ static int log_write(const void *data, unsigned size)
 	return 0;
 }
 
-static int strlen(const char *p)
-{
-	int count = 0;
-
-	while (*p++) count++;
-
-	return count;
-}
-
 #define EV_NO_ACTION    0x3
 /* TODO: are these types defined anywhere? */
 #define EV_TYPE_SKINIT  0x600

--- a/include/types.h
+++ b/include/types.h
@@ -78,5 +78,8 @@ void *memset(void *s, int c, size_t n);
 void *memcpy(void *dst, const void *src, size_t n);
 #define memcpy(d, s, n) __builtin_memcpy(d, s, n)
 
+size_t strlen(const char *s);
+#define strlen(s)       __builtin_strlen(s)
+
 #endif /* __STDC_HOSTED__ */
 #endif /* __TYPES_H__ */

--- a/string.c
+++ b/string.c
@@ -20,3 +20,13 @@ void *(memset)(void *dst, int c, size_t n)
 
 	return dst;
 }
+
+size_t (strlen)(const char *s)
+{
+	size_t c = 0;
+
+	while (*s++)
+		c++;
+
+	return c;
+}


### PR DESCRIPTION
In particular, this now shinks to a single `rep scas`.

While moving the implementation to string.c, fix the ABI to match the C
standard, by using size_t rather than int.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>