### PR TITLE
IOMMU: Minor perf and size improvements

### DIFF
--- a/include/boot.h
+++ b/include/boot.h
@@ -75,6 +75,10 @@ extern lz_header_t lz_header;
 #define wmb()		asm volatile("sfence" : : : "memory")
 #define barrier()	asm volatile("" : : : "memory")
 
+#define smp_rmb()	barrier()
+#define smp_wmb()	barrier()
+#define smp_mb()	mb()
+
 /* MMIO Functions */
 static inline u8 ioread8(void *addr)
 {


### PR DESCRIPTION
First, introduce the smp_*() barriers, and replace the incorrect (but benign
on x86) usage of barrier() for the purpose of smp_wmb().

The IOMMU is another coherent agent system, and the ordering requirements here
are so it observes the writes in the correct order.

Drop the wbinvd/sfence's and use smp_wmb().  There is no need to flush the
entire cache, or to use an explicit sfence.

Calculate mmio_base locally in iommu_load_device_table() and pass it in to
send_command().  Specifically, this means it doesn't need to be
recalculated (re-loaded from the static variable) after every barrier.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>